### PR TITLE
Add all questions and announcements screens

### DIFF
--- a/app/lib/app_route_generator.dart
+++ b/app/lib/app_route_generator.dart
@@ -1,5 +1,6 @@
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/all_questions_screen.dart';
 import 'package:app/ui/screen/announcements_screen.dart';
 import 'package:app/ui/screen/home_screen.dart';
 import 'package:app/ui/screen/log_in_screen.dart';
@@ -30,6 +31,8 @@ class AppRouteGenerator {
             return LogInScreen();
           case AnnouncementsScreen.route:
             return AnnouncementsScreen();
+          case AllQuestionsScreen.route:
+            return AllQuestionsScreen();
           case ThreadDisplayScreen.route:
             return ThreadDisplayScreen(initial: settings.arguments as Thread);
 

--- a/app/lib/app_route_generator.dart
+++ b/app/lib/app_route_generator.dart
@@ -1,5 +1,6 @@
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/announcements_screen.dart';
 import 'package:app/ui/screen/home_screen.dart';
 import 'package:app/ui/screen/log_in_screen.dart';
 import 'package:app/ui/screen/my_questions_screen.dart';
@@ -27,6 +28,8 @@ class AppRouteGenerator {
             return SignUpScreen();
           case LogInScreen.route:
             return LogInScreen();
+          case AnnouncementsScreen.route:
+            return AnnouncementsScreen();
           case ThreadDisplayScreen.route:
             return ThreadDisplayScreen(initial: settings.arguments as Thread);
 

--- a/app/lib/service/firebase_database_service.dart
+++ b/app/lib/service/firebase_database_service.dart
@@ -82,6 +82,16 @@ class FirebaseDatabaseService {
               Thread.fromJson(id: doc.id, json: doc.data()!))
           .toList());
 
+  Future<Thread> getLatestAnnouncementThread() => _firestore
+      .collection('announcementThread')
+      .orderBy("startDate")
+      .limitToLast(1)
+      .get()
+      .then((QuerySnapshot snapshot) => snapshot.docs
+          .map((QueryDocumentSnapshot doc) =>
+              Thread.fromJson(id: doc.id, json: doc.data()!))
+          .first);
+
   Stream<List<Thread>> getAllUpdatedThreads() => _firestore
       .collection('thread')
       .snapshots()

--- a/app/lib/service/firebase_database_service.dart
+++ b/app/lib/service/firebase_database_service.dart
@@ -74,6 +74,14 @@ class FirebaseDatabaseService {
               Thread.fromJson(id: doc.id, json: doc.data()!))
           .first);
 
+  Stream<List<Thread>> getUpdatedAnnouncementThreads() => _firestore
+      .collection('announcementThread')
+      .snapshots()
+      .map((QuerySnapshot snapshot) => snapshot.docs
+          .map((QueryDocumentSnapshot doc) =>
+              Thread.fromJson(id: doc.id, json: doc.data()!))
+          .toList());
+
   Stream<List<Thread>> getAllUpdatedThreads() => _firestore
       .collection('thread')
       .snapshots()

--- a/app/lib/service/service_locator.dart
+++ b/app/lib/service/service_locator.dart
@@ -2,6 +2,7 @@ import 'package:app/service/dialog_service.dart';
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/firebase_database_service.dart';
 import 'package:app/service/navigation_service.dart';
+import 'package:app/ui/view_model/announcements_view_model.dart';
 import 'package:app/ui/view_model/home_view_model.dart';
 import 'package:app/ui/view_model/log_in_view_model.dart';
 import 'package:app/ui/view_model/my_questions_view_model.dart';
@@ -31,5 +32,6 @@ class ServiceLocator {
     get.registerFactory<NewQuestionViewModel>(() => NewQuestionViewModel());
     get.registerFactory<MyQuestionsViewModel>(() => MyQuestionsViewModel());
     get.registerFactory<ThreadViewModel>(() => ThreadViewModel());
+    get.registerFactory<AnnouncementsViewModel>(() => AnnouncementsViewModel());
   }
 }

--- a/app/lib/service/service_locator.dart
+++ b/app/lib/service/service_locator.dart
@@ -2,6 +2,7 @@ import 'package:app/service/dialog_service.dart';
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/firebase_database_service.dart';
 import 'package:app/service/navigation_service.dart';
+import 'package:app/ui/view_model/all_questions_view_model.dart';
 import 'package:app/ui/view_model/announcements_view_model.dart';
 import 'package:app/ui/view_model/home_view_model.dart';
 import 'package:app/ui/view_model/log_in_view_model.dart';
@@ -33,5 +34,6 @@ class ServiceLocator {
     get.registerFactory<MyQuestionsViewModel>(() => MyQuestionsViewModel());
     get.registerFactory<ThreadViewModel>(() => ThreadViewModel());
     get.registerFactory<AnnouncementsViewModel>(() => AnnouncementsViewModel());
+    get.registerFactory<AllQuestionsViewModel>(() => AllQuestionsViewModel());
   }
 }

--- a/app/lib/ui/screen/all_questions_screen.dart
+++ b/app/lib/ui/screen/all_questions_screen.dart
@@ -1,6 +1,6 @@
 import 'package:app/core/thread.dart';
 import 'package:app/ui/style.dart';
-import 'package:app/ui/view_model/announcements_view_model.dart';
+import 'package:app/ui/view_model/all_questions_view_model.dart';
 import 'package:app/ui/widget/custom_app_bar.dart';
 import 'package:app/ui/widget/custom_bottom_app_bar.dart';
 import 'package:app/ui/widget/template_view_model.dart';
@@ -8,15 +8,14 @@ import 'package:app/ui/widget/thread_preview_card.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
-class AnnouncementsScreen extends StatefulWidget {
-  static const route = '/announcements';
+class AllQuestionsScreen extends StatefulWidget {
+  static const route = '/allQuestions';
 
-  _AnnouncementsScreenState createState() => _AnnouncementsScreenState();
+  _AllQuestionsScreenState createState() => _AllQuestionsScreenState();
 }
 
-class _AnnouncementsScreenState extends State<AnnouncementsScreen> {
-  ThreadPreviewCard createPreview(
-          AnnouncementsViewModel model, Thread thread) =>
+class _AllQuestionsScreenState extends State<AllQuestionsScreen> {
+  ThreadPreviewCard createPreview(AllQuestionsViewModel model, Thread thread) =>
       ThreadPreviewCard(
           // Must have unique keys in rebuilding widget lists
           key: ObjectKey(Uuid().v4()),
@@ -25,7 +24,7 @@ class _AnnouncementsScreenState extends State<AnnouncementsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return TemplateViewModel<AnnouncementsViewModel>(
+    return TemplateViewModel<AllQuestionsViewModel>(
       builder: (context, model, _) => Scaffold(
         appBar: CustomAppBar.get(
             leftButtonText: "Account",
@@ -39,14 +38,14 @@ class _AnnouncementsScreenState extends State<AnnouncementsScreen> {
               // TODO
             }),
         bottomNavigationBar: CustomBottomAppBar.get(),
-        body: model.announcements.isEmpty
+        body: model.questions.isEmpty
             ? Center(
                 child: Container(
                   margin: EdgeInsets.all(50.0),
                   child: Card(
                     child: ListTile(
                       title: Text(
-                        "There are no announcements yet",
+                        "Looks like there's been no questions yet. Be the first!",
                         textAlign: TextAlign.center,
                         style: TextStyle(fontSize: LargeTextSize),
                       ),
@@ -55,9 +54,9 @@ class _AnnouncementsScreenState extends State<AnnouncementsScreen> {
                 ),
               )
             : ListView.builder(
-                itemCount: model.announcements.length,
+                itemCount: model.questions.length,
                 itemBuilder: (context, index) =>
-                    createPreview(model, model.announcements[index]),
+                    createPreview(model, model.questions[index]),
               ),
       ),
     );

--- a/app/lib/ui/screen/announcements_screen.dart
+++ b/app/lib/ui/screen/announcements_screen.dart
@@ -1,6 +1,6 @@
 import 'package:app/core/thread.dart';
 import 'package:app/ui/style.dart';
-import 'package:app/ui/view_model/my_questions_view_model.dart';
+import 'package:app/ui/view_model/announcements_view_model.dart';
 import 'package:app/ui/widget/custom_app_bar.dart';
 import 'package:app/ui/widget/custom_bottom_app_bar.dart';
 import 'package:app/ui/widget/template_view_model.dart';
@@ -8,14 +8,15 @@ import 'package:app/ui/widget/thread_preview_card.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
-class MyQuestionsScreen extends StatefulWidget {
-  static const route = '/myQuestions';
+class AnnouncementsScreen extends StatefulWidget {
+  static const route = '/announcements';
 
   _MyQuestionScreenState createState() => _MyQuestionScreenState();
 }
 
-class _MyQuestionScreenState extends State<MyQuestionsScreen> {
-  ThreadPreviewCard createPreview(MyQuestionsViewModel model, Thread thread) =>
+class _MyQuestionScreenState extends State<AnnouncementsScreen> {
+  ThreadPreviewCard createPreview(
+          AnnouncementsViewModel model, Thread thread) =>
       ThreadPreviewCard(
           // Must have unique keys in rebuilding widget lists
           key: ObjectKey(Uuid().v4()),
@@ -24,7 +25,7 @@ class _MyQuestionScreenState extends State<MyQuestionsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return TemplateViewModel<MyQuestionsViewModel>(
+    return TemplateViewModel<AnnouncementsViewModel>(
       builder: (context, model, _) => Scaffold(
         appBar: CustomAppBar.get(
             leftButtonText: "Account",
@@ -38,29 +39,25 @@ class _MyQuestionScreenState extends State<MyQuestionsScreen> {
               // TODO
             }),
         bottomNavigationBar: CustomBottomAppBar.get(),
-        body: model.threads.isEmpty
+        body: model.announcements.isEmpty
             ? Center(
                 child: Container(
                   margin: EdgeInsets.all(50.0),
                   child: Card(
                     child: ListTile(
-                        title: Text(
-                          "You have no questions yet",
-                          textAlign: TextAlign.center,
-                          style: TextStyle(fontSize: LargeTextSize),
-                        ),
-                        subtitle: Text(
-                          "You can ask some using the \"New Question\" button on the home page",
-                          textAlign: TextAlign.center,
-                          style: TextStyle(fontSize: MediumTextSize),
-                        )),
+                      title: Text(
+                        "There are no announcements yet",
+                        textAlign: TextAlign.center,
+                        style: TextStyle(fontSize: LargeTextSize),
+                      ),
+                    ),
                   ),
                 ),
               )
             : ListView.builder(
-                itemCount: model.threads.length,
+                itemCount: model.announcements.length,
                 itemBuilder: (context, index) =>
-                    createPreview(model, model.threads[index]),
+                    createPreview(model, model.announcements[index]),
               ),
       ),
     );

--- a/app/lib/ui/screen/home_screen.dart
+++ b/app/lib/ui/screen/home_screen.dart
@@ -18,7 +18,103 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  Widget _buildLatestQuestionMaybe(
+  @override
+  Widget build(BuildContext context) {
+    return TemplateViewModel<HomeViewModel>(
+        builder: (context, model, child) => FutureBuilder<Thread>(
+            future: model.latestAnnouncement,
+            builder: (BuildContext context,
+                AsyncSnapshot<Thread> announcementSnapshot) {
+              return FutureBuilder<Thread>(
+                  future: model.latestMyQuestion,
+                  builder: (BuildContext context,
+                      AsyncSnapshot<Thread> questionSnapshot) {
+                    return Scaffold(
+                      appBar: CustomAppBar.get(
+                          leftButtonText: "Signup",
+                          centreButtonText: "Account",
+                          rightButtonText: "FAQ",
+                          leftButtonAction: model.navigateToSignUpScreen,
+                          centreButtonAction: () {
+                            // TODO
+                          },
+                          rightButtonAction: () {
+                            // TODO
+                          }),
+                      bottomNavigationBar: CustomBottomAppBar.get(),
+                      body: Center(
+                        child: SingleChildScrollView(
+                          child: Column(
+                            children: [
+                              stretchedButton(
+                                  text: "Announcements",
+                                  trailing:
+                                      Icon(Icons.arrow_forward_ios_outlined),
+                                  onPressed:
+                                      model.navigateToAnnouncementsScreen,
+                                  color: PersianGreen,
+                                  pressedColor: PersianGreenOpaque),
+                              Padding(
+                                padding: EdgeInsets.only(bottom: 10.0),
+                              ),
+                              ListTile(
+                                title: Text(
+                                  "Since last time...",
+                                  style: GoogleFonts.cabin(color: PersianGreen),
+                                ),
+                                subtitle: _buildLatestWidget(
+                                    model, announcementSnapshot),
+                              ),
+                              Padding(
+                                padding: EdgeInsets.only(bottom: 15.0),
+                              ),
+                              stretchedButton(
+                                  text: "My Questions",
+                                  trailing:
+                                      Icon(Icons.arrow_forward_ios_outlined),
+                                  onPressed: model.navigateToMyQuestionsScreen,
+                                  color: PersianGreen,
+                                  pressedColor: PersianGreenOpaque),
+                              Padding(
+                                padding: EdgeInsets.only(bottom: 10.0),
+                              ),
+                              ListTile(
+                                title: Text(
+                                  "Since last time...",
+                                  style: GoogleFonts.cabin(color: PersianGreen),
+                                ),
+                                subtitle:
+                                    _buildLatestWidget(model, questionSnapshot),
+                              ),
+                              Padding(
+                                padding: EdgeInsets.only(bottom: 45.0),
+                              ),
+                              elevatedButton(
+                                  text: "Ask a new question",
+                                  trailing:
+                                      Icon(Icons.arrow_forward_ios_outlined),
+                                  onPressed: model.navigateToNewQuestionScreen,
+                                  color: BurntSienna,
+                                  pressedColor: PersianGreenOpaque),
+                              Padding(
+                                padding: EdgeInsets.only(bottom: 45.0),
+                              ),
+                              elevatedButton(
+                                  text: "Logout (Temporary) ",
+                                  trailing: Icon(Icons.logout),
+                                  onPressed: model.logOut,
+                                  color: BurntSienna,
+                                  pressedColor: PersianGreenOpaque)
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  });
+            }));
+  }
+
+  Widget _buildLatestWidget(
       HomeViewModel model, AsyncSnapshot<Thread> snapshot) {
     if (snapshot.hasData) {
       return ThreadPreviewCard(
@@ -41,70 +137,5 @@ class _HomeScreenState extends State<HomeScreen> {
           childAlignmentInBox: Alignment.center,
           color: PersianGreen);
     }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return TemplateViewModel<HomeViewModel>(
-        builder: (context, model, child) => FutureBuilder<Thread>(
-            future: model.latestMyQuestion,
-            builder: (BuildContext context, AsyncSnapshot<Thread> snapshot) {
-              return Scaffold(
-                appBar: CustomAppBar.get(
-                    leftButtonText: "Signup",
-                    centreButtonText: "Account",
-                    rightButtonText: "FAQ",
-                    leftButtonAction: model.navigateToSignUpScreen,
-                    centreButtonAction: () {
-                      // TODO
-                    },
-                    rightButtonAction: () {
-                      // TODO
-                    }),
-                bottomNavigationBar: CustomBottomAppBar.get(),
-                body: Center(
-                  child: SingleChildScrollView(
-                    child: Column(
-                      children: [
-                        stretchedButton(
-                            text: "My Questions",
-                            trailing: Icon(Icons.arrow_forward_ios_outlined),
-                            onPressed: model.navigateToMyQuestionsScreen,
-                            color: PersianGreen,
-                            pressedColor: PersianGreenOpaque),
-                        Padding(
-                          padding: EdgeInsets.only(bottom: 10.0),
-                        ),
-                        ListTile(
-                          title: Text(
-                            "Since last time...",
-                            style: GoogleFonts.cabin(color: PersianGreen),
-                          ),
-                          subtitle: _buildLatestQuestionMaybe(model, snapshot),
-                        ),
-                        Padding(
-                          padding: EdgeInsets.only(bottom: 45.0),
-                        ),
-                        elevatedButton(
-                            text: "Ask a new question",
-                            trailing: Icon(Icons.arrow_forward_ios_outlined),
-                            onPressed: model.navigateToNewQuestionScreen,
-                            color: BurntSienna,
-                            pressedColor: PersianGreenOpaque),
-                        Padding(
-                          padding: EdgeInsets.only(bottom: 45.0),
-                        ),
-                        elevatedButton(
-                            text: "Logout (Temporary) ",
-                            trailing: Icon(Icons.logout),
-                            onPressed: model.logOut,
-                            color: BurntSienna,
-                            pressedColor: PersianGreenOpaque)
-                      ],
-                    ),
-                  ),
-                ),
-              );
-            }));
   }
 }

--- a/app/lib/ui/screen/home_screen.dart
+++ b/app/lib/ui/screen/home_screen.dart
@@ -47,20 +47,30 @@ class _HomeScreenState extends State<HomeScreen> {
                           child: Column(
                             children: [
                               stretchedButton(
+                                  text: "All Questions",
+                                  trailing:
+                                      Icon(Icons.arrow_forward_ios_outlined),
+                                  onPressed: model.navigateToAllQuestionsScreen,
+                                  color: PersianGreen,
+                                  pressedColor: PersianGreenOpaque),
+                              Padding(
+                                padding: EdgeInsets.only(bottom: 15.0),
+                              ),
+                              stretchedButton(
                                   text: "Announcements",
                                   trailing:
                                       Icon(Icons.arrow_forward_ios_outlined),
                                   onPressed:
                                       model.navigateToAnnouncementsScreen,
-                                  color: PersianGreen,
-                                  pressedColor: PersianGreenOpaque),
+                                  color: BurntSienna,
+                                  pressedColor: BurntSiennaOpaque),
                               Padding(
                                 padding: EdgeInsets.only(bottom: 10.0),
                               ),
                               ListTile(
                                 title: Text(
                                   "Since last time...",
-                                  style: GoogleFonts.cabin(color: PersianGreen),
+                                  style: GoogleFonts.cabin(color: BurntSienna),
                                 ),
                                 subtitle: _buildLatestWidget(
                                     model, announcementSnapshot),
@@ -87,7 +97,7 @@ class _HomeScreenState extends State<HomeScreen> {
                                     _buildLatestWidget(model, questionSnapshot),
                               ),
                               Padding(
-                                padding: EdgeInsets.only(bottom: 45.0),
+                                padding: EdgeInsets.only(bottom: 25.0),
                               ),
                               elevatedButton(
                                   text: "Ask a new question",

--- a/app/lib/ui/view_model/all_questions_view_model.dart
+++ b/app/lib/ui/view_model/all_questions_view_model.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+
+import 'package:app/core/thread.dart';
+import 'package:app/service/firebase_database_service.dart';
+import 'package:app/service/navigation_service.dart';
+import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/home_screen.dart';
+import 'package:app/ui/screen/thread_display_screen.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+import 'package:flutter/foundation.dart';
+
+class AllQuestionsViewModel extends ViewModel {
+  final _navigationService = ServiceLocator.get<NavigationService>();
+  final _databaseService = ServiceLocator.get<FirebaseDatabaseService>();
+  StreamSubscription<List<Thread>>? _questionsSubscription;
+
+  final List<Thread> _questions = [];
+
+  List<Thread> get questions => List.unmodifiable(_questions);
+
+  @mustCallSuper
+  void dispose() {
+    removeAll();
+    if (_questionsSubscription != null) _questionsSubscription!.cancel();
+    super.dispose();
+  }
+
+  AllQuestionsViewModel() {
+    _questionsSubscription = _databaseService
+        .getAllUpdatedThreads()
+        .listen((List<Thread> questions) {
+      removeAll();
+      addAll(questions);
+    });
+  }
+
+  void addAll(List<Thread> questions) {
+    _questions.addAll(questions);
+    notifyListeners();
+  }
+
+  void removeAll() {
+    _questions.clear();
+    notifyListeners();
+  }
+
+  void navigateToThreadDisplayScreen(Thread thread) {
+    _navigationService.navigateTo(ThreadDisplayScreen.route, arguments: thread);
+  }
+
+  void navigateToHomeScreen() =>
+      _navigationService.navigateBackUntil(HomeScreen.route);
+}

--- a/app/lib/ui/view_model/announcements_view_model.dart
+++ b/app/lib/ui/view_model/announcements_view_model.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:app/core/thread.dart';
+import 'package:app/service/firebase_database_service.dart';
+import 'package:app/service/navigation_service.dart';
+import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/home_screen.dart';
+import 'package:app/ui/screen/thread_display_screen.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+import 'package:flutter/foundation.dart';
+
+class AnnouncementsViewModel extends ViewModel {
+  final _navigationService = ServiceLocator.get<NavigationService>();
+  final _databaseService = ServiceLocator.get<FirebaseDatabaseService>();
+  StreamSubscription<List<Thread>>? _announcementsSubscription;
+
+  final List<Thread> _announcements = [];
+
+  List<Thread> get announcements => List.unmodifiable(_announcements);
+
+  @mustCallSuper
+  void dispose() {
+    removeAll();
+    if (_announcementsSubscription != null)
+      _announcementsSubscription!.cancel();
+    super.dispose();
+  }
+
+  AnnouncementsViewModel() {
+    _announcementsSubscription = _databaseService
+        .getUpdatedAnnouncementThreads()
+        .listen((List<Thread> announcements) {
+      removeAll();
+      addAll(announcements);
+    });
+  }
+
+  void addAll(List<Thread> announcements) {
+    _announcements.addAll(announcements);
+    notifyListeners();
+  }
+
+  void removeAll() {
+    _announcements.clear();
+    notifyListeners();
+  }
+
+  void navigateToThreadDisplayScreen(Thread thread) {
+    _navigationService.navigateTo(ThreadDisplayScreen.route, arguments: thread);
+  }
+
+  void navigateToHomeScreen() =>
+      _navigationService.navigateBackUntil(HomeScreen.route);
+}

--- a/app/lib/ui/view_model/home_view_model.dart
+++ b/app/lib/ui/view_model/home_view_model.dart
@@ -42,9 +42,18 @@ class HomeViewModel extends ViewModel {
   void _setLatestMyQuestion(User? user) => latestMyQuestion = user != null
       ? _databaseService
           .getLatestAccountSpecificThread(user.uid)
-          // TODO: Should log the failure reason (don't use dialog pop-up)
-          .catchError((error) => Future<Thread>.error(
-              "It doesn't look like you have any questions!"))
+          .catchError((error) {
+          if (error.message == "No element") {
+            return Future<Thread>.error(
+                "It looks like you don't have any questions.");
+          } else {
+            _dialogService.showDialog(
+                title: "Getting the latest question failed!",
+                description:
+                    "Here's what we think went wrong\n${error.message}");
+            return Future<Thread>.error("Getting the latest question failed");
+          }
+        })
       : Future<Thread>.error(
           "Cannot see the latest question if you're not logged in!");
 

--- a/app/lib/ui/view_model/home_view_model.dart
+++ b/app/lib/ui/view_model/home_view_model.dart
@@ -7,6 +7,7 @@ import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/firebase_database_service.dart';
 import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/announcements_screen.dart';
 import 'package:app/ui/screen/my_questions_screen.dart';
 import 'package:app/ui/screen/new_question_screen.dart';
 import 'package:app/ui/screen/sign_up_screen.dart';
@@ -22,6 +23,7 @@ class HomeViewModel extends ViewModel {
   final _dialogService = ServiceLocator.get<DialogService>();
   StreamSubscription<User?>? _currentUserSubscription;
   late Future<Thread> latestMyQuestion;
+  late Future<Thread> latestAnnouncement;
 
   @mustCallSuper
   void dispose() {
@@ -31,6 +33,7 @@ class HomeViewModel extends ViewModel {
 
   HomeViewModel() {
     _setLatestMyQuestion(_firebaseAuthService.currentUser);
+    _setLatestAnnouncement();
     notifyListeners();
     _currentUserSubscription =
         _firebaseAuthService.currentUserChanges.listen((User? user) {
@@ -56,6 +59,19 @@ class HomeViewModel extends ViewModel {
         })
       : Future<Thread>.error(
           "Cannot see the latest question if you're not logged in!");
+
+  void _setLatestAnnouncement() => latestAnnouncement =
+          _databaseService.getLatestAnnouncementThread().catchError((error) {
+        if (error.message == "No element") {
+          return Future<Thread>.error(
+              "It looks like there are no announcements yet.");
+        } else {
+          _dialogService.showDialog(
+              title: "Getting the latest announcement failed!",
+              description: "Here's what we think went wrong\n${error.message}");
+          return Future<Thread>.error("Getting the latest announcement failed");
+        }
+      });
 
   Future<Thread> _createNewThread() async {
     final thisUser = _firebaseAuthService.currentUser;
@@ -113,6 +129,9 @@ class HomeViewModel extends ViewModel {
 
   void navigateToThreadDisplayScreen(Thread thread) => _navigationService
       .navigateTo(ThreadDisplayScreen.route, arguments: thread);
+
+  void navigateToAnnouncementsScreen() =>
+      _navigationService.navigateTo(AnnouncementsScreen.route);
 
   void logOut() => _firebaseAuthService.signOut();
 }

--- a/app/lib/ui/view_model/home_view_model.dart
+++ b/app/lib/ui/view_model/home_view_model.dart
@@ -7,6 +7,7 @@ import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/firebase_database_service.dart';
 import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/all_questions_screen.dart';
 import 'package:app/ui/screen/announcements_screen.dart';
 import 'package:app/ui/screen/my_questions_screen.dart';
 import 'package:app/ui/screen/new_question_screen.dart';
@@ -132,6 +133,9 @@ class HomeViewModel extends ViewModel {
 
   void navigateToAnnouncementsScreen() =>
       _navigationService.navigateTo(AnnouncementsScreen.route);
+
+  void navigateToAllQuestionsScreen() =>
+      _navigationService.navigateTo(AllQuestionsScreen.route);
 
   void logOut() => _firebaseAuthService.signOut();
 }


### PR DESCRIPTION
Closes #49 .

This PR adds the announcements and all questions screens. Also adds the latest announcement on the home page since last login.

***

Changes look like:

![Screen Shot 2021-03-23 at 12 31 57 AM](https://user-images.githubusercontent.com/32527219/112103595-9c02ec00-8b6f-11eb-87a5-909233d5d792.png)
![Screen Shot 2021-03-23 at 12 32 13 AM](https://user-images.githubusercontent.com/32527219/112103596-9c9b8280-8b6f-11eb-9f1b-a0bbef66b52e.png)
