### PR TITLE
Add admin application core type

### DIFF
--- a/app/lib/core/administration_application.dart
+++ b/app/lib/core/administration_application.dart
@@ -1,0 +1,66 @@
+import 'package:app/core/approval_status.dart';
+import 'package:flutter/foundation.dart';
+
+@immutable
+class AdministrationApplication {
+  final String applicantName;
+  final String applicantId; // Also the Firebase Firestore ID
+  final DateTime submissionDate;
+  final ApprovalStatus approvalStatus;
+
+  AdministrationApplication(
+      {required this.applicantName,
+      required this.applicantId,
+      required this.submissionDate,
+      required this.approvalStatus});
+
+  AdministrationApplication.empty(String id)
+      : applicantName = "",
+        applicantId = "",
+        submissionDate = DateTime.now(),
+        approvalStatus = ApprovalStatus.nothing;
+
+  AdministrationApplication.fromJson(
+      {required String id, required Map<String, dynamic> json})
+      : applicantName = json['applicantName'],
+        applicantId = id,
+        submissionDate = json['submissionDate'].toDate(),
+        approvalStatus =
+            ApprovalStatusDeserializer.fromString(json['approvalStatus']);
+
+  Map<String, dynamic> toJson() => {
+        'applicantName': applicantName,
+        'applicantId': applicantId,
+        'submissionDate': submissionDate,
+        'approvalStatus': approvalStatus.toString()
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AdministrationApplication &&
+          runtimeType == other.runtimeType &&
+          applicantName == other.applicantName &&
+          applicantId == other.applicantId &&
+          submissionDate == other.submissionDate &&
+          approvalStatus == other.approvalStatus;
+
+  @override
+  int get hashCode =>
+      applicantName.hashCode ^
+      applicantId.hashCode ^
+      submissionDate.hashCode ^
+      approvalStatus.hashCode;
+
+  @override
+  String toString() {
+    return 'AdministrationApplication{applicantName: $applicantName, applicantId: $applicantId, submissionDate: $submissionDate, approvalStatus: $approvalStatus}';
+  }
+
+  AdministrationApplication withApprovalStatus(ApprovalStatus newStatus) =>
+      AdministrationApplication(
+          applicantName: applicantName,
+          applicantId: applicantId,
+          submissionDate: submissionDate,
+          approvalStatus: newStatus);
+}

--- a/app/lib/core/approval_status.dart
+++ b/app/lib/core/approval_status.dart
@@ -1,0 +1,24 @@
+import 'package:recase/recase.dart';
+
+enum ApprovalStatus { approved, denied, nothing, undefined }
+
+/// Particularly used for JSON conversion
+extension ApprovalStatusDeserializer on ApprovalStatus {
+  static ApprovalStatus fromString(String it) {
+    for (ApprovalStatus subTopic in ApprovalStatus.values) {
+      if (subTopic.toString() == it) {
+        return subTopic;
+      }
+    }
+    return ApprovalStatus.undefined;
+  }
+}
+
+extension ApprovalStatusString on ApprovalStatus {
+  static String toDisplayString(ApprovalStatus it) =>
+      ReCase(it.toString().split('.').last).sentenceCase;
+
+  static ApprovalStatus fromDisplayString(String it) =>
+      ApprovalStatusDeserializer.fromString(
+          'ApprovalStatus.${ReCase(it).camelCase}');
+}

--- a/app/lib/service/firebase_database_service.dart
+++ b/app/lib/service/firebase_database_service.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 
 import 'package:app/core/account.dart';
+import 'package:app/core/administration_application.dart';
 import 'package:app/core/post.dart';
 import 'package:app/core/thread.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 /// A service wrapping Firebase Firestore, specifically for the app
+/// TODO: Split this service up based on types
 class FirebaseDatabaseService {
   final _firestore = ServiceLocator.get<FirebaseFirestore>();
 
@@ -162,5 +164,27 @@ class FirebaseDatabaseService {
           .map((QuerySnapshot snapshot) => snapshot.docs
               .map((QueryDocumentSnapshot doc) =>
                   Post.fromJson(id: doc.id, json: doc.data()!))
+              .toList());
+
+  Future<void> addAdminApplication(
+          AdministrationApplication application) async =>
+      _firestore
+          .collection('adminApplication')
+          .doc(application.applicantId)
+          .set(application.toJson());
+
+  Future<void> updateAdminApplication(
+          AdministrationApplication application) async =>
+      _firestore
+          .collection('adminApplication')
+          .doc(application.applicantId)
+          .update(application.toJson());
+
+  Stream<List<AdministrationApplication>> getAllUpdatedAdminApplications() =>
+      _firestore.collection('adminApplication').snapshots().map(
+          (QuerySnapshot snapshot) => snapshot.docs
+              .map((QueryDocumentSnapshot doc) =>
+                  AdministrationApplication.fromJson(
+                      id: doc.id, json: doc.data()!))
               .toList());
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "18.0.0"
+    version: "19.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   args:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   code_builder:
     dependency: transitive
     description:
@@ -189,7 +189,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.14"
+    version: "2.0.0"
   fake_async:
     dependency: transitive
     description:
@@ -288,7 +288,7 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   google_fonts:
     dependency: "direct main"
     description:
@@ -358,7 +358,7 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:
@@ -386,7 +386,7 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.2"
+    version: "5.0.3"
   nested:
     dependency: transitive
     description:
@@ -477,7 +477,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
+    version: "4.2.1"
   provider:
     dependency: "direct main"
     description:
@@ -531,7 +531,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.10+4"
+    version: "1.0.0"
   source_span:
     dependency: transitive
     description:
@@ -601,7 +601,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   vector_math:
     dependency: transitive
     description:
@@ -629,7 +629,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
Closes #66 .

This PR adds:
1. The `AdminApplication` core and database types
2. The `ApprovalStatus` enum
3. Functions to database service for admin application