### PR TITLE
Add flag thread menu to all threads

### DIFF
--- a/app/lib/service/firestore_admin_service.dart
+++ b/app/lib/service/firestore_admin_service.dart
@@ -31,10 +31,8 @@ class FirestoreAdminService {
                       id: doc.id, json: doc.data()!))
               .toList());
 
-  Future<void> addThreadFlag(ThreadFlag threadFlag) async => _firestore
-      .collection('threadFlag')
-      .doc(threadFlag.id)
-      .set(threadFlag.toJson());
+  Future<void> addThreadFlag(ThreadFlag threadFlag) async =>
+      _firestore.collection('threadFlag').add(threadFlag.toJson());
 
   Future<void> removeThreadFlag(String id) async =>
       _firestore.collection('threadFlag').doc(id).delete();


### PR DESCRIPTION
Closes #72 . Probably needs revisiting to differentiate between announcement threads and question threads.

This PR adds:
1. The problems menu to all threads

***

Changes look like:

![Screen Shot 2021-03-30 at 10 50 53 PM](https://user-images.githubusercontent.com/32527219/113092296-f7099400-91aa-11eb-88cf-cd4bcae48431.png)
