### PR TITLE
Add leadership application pages

### DIFF
--- a/app/lib/app_route_generator.dart
+++ b/app/lib/app_route_generator.dart
@@ -2,6 +2,7 @@ import 'package:app/core/thread.dart';
 import 'package:app/core/thread_type.dart';
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/application_confirmation_screen.dart';
 import 'package:app/ui/screen/application_screen.dart';
 import 'package:app/ui/screen/flagged_threads_screen.dart';
 import 'package:app/ui/screen/home_screen.dart';
@@ -82,6 +83,14 @@ class AppRouteGenerator {
           case FlaggedThreadsScreen.route:
             if (isLoggedIn() && isAdmin()) {
               return FlaggedThreadsScreen<FlaggedThreadsViewModel>();
+            } else {
+              throw Exception(
+                  'You must be logged in to view this screen: ${settings.name}');
+            }
+
+          case ApplicationConfirmationScreen.route:
+            if (isLoggedIn()) {
+              return ApplicationConfirmationScreen();
             } else {
               throw Exception(
                   'You must be logged in to view this screen: ${settings.name}');

--- a/app/lib/app_route_generator.dart
+++ b/app/lib/app_route_generator.dart
@@ -2,6 +2,7 @@ import 'package:app/core/thread.dart';
 import 'package:app/core/thread_type.dart';
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/application_screen.dart';
 import 'package:app/ui/screen/flagged_threads_screen.dart';
 import 'package:app/ui/screen/home_screen.dart';
 import 'package:app/ui/screen/log_in_screen.dart';
@@ -81,6 +82,14 @@ class AppRouteGenerator {
           case FlaggedThreadsScreen.route:
             if (isLoggedIn() && isAdmin()) {
               return FlaggedThreadsScreen<FlaggedThreadsViewModel>();
+            } else {
+              throw Exception(
+                  'You must be logged in to view this screen: ${settings.name}');
+            }
+
+          case ApplicationScreen.route:
+            if (isLoggedIn()) {
+              return ApplicationScreen<MyQuestionsViewModel>();
             } else {
               throw Exception(
                   'You must be logged in to view this screen: ${settings.name}');

--- a/app/lib/service/firestore_admin_service.dart
+++ b/app/lib/service/firestore_admin_service.dart
@@ -24,8 +24,11 @@ class FirestoreAdminService {
           .update(application.toJson());
 
   Stream<List<AdministrationApplication>> getAllUpdatedAdminApplications() =>
-      _firestore.collection('adminApplication').snapshots().map(
-          (QuerySnapshot snapshot) => snapshot.docs
+      _firestore
+          .collection('adminApplication')
+          .orderBy("submissionDate")
+          .snapshots()
+          .map((QuerySnapshot snapshot) => snapshot.docs
               .map((QueryDocumentSnapshot doc) =>
                   AdministrationApplication.fromJson(
                       id: doc.id, json: doc.data()!))

--- a/app/lib/service/service_locator.dart
+++ b/app/lib/service/service_locator.dart
@@ -8,6 +8,7 @@ import 'package:app/service/navigation_service.dart';
 import 'package:app/ui/view_model/all_questions_view_model.dart';
 import 'package:app/ui/view_model/announcement_view_model.dart';
 import 'package:app/ui/view_model/announcements_view_model.dart';
+import 'package:app/ui/view_model/application_screen_view_model.dart';
 import 'package:app/ui/view_model/flagged_threads_view_model.dart';
 import 'package:app/ui/view_model/home_view_model.dart';
 import 'package:app/ui/view_model/log_in_view_model.dart';
@@ -52,5 +53,6 @@ class ServiceLocator {
     get.registerFactory<NewQuestionViewModel>(() => NewQuestionViewModel());
     get.registerFactory<FlaggedThreadsViewModel>(
         () => FlaggedThreadsViewModel());
+    get.registerFactory<ApplicationViewModel>(() => ApplicationViewModel());
   }
 }

--- a/app/lib/ui/screen/application_confirmation_screen.dart
+++ b/app/lib/ui/screen/application_confirmation_screen.dart
@@ -1,0 +1,113 @@
+import 'dart:ui';
+
+import 'package:app/ui/style.dart';
+import 'package:app/ui/view_model/application_screen_view_model.dart';
+import 'package:app/ui/widget/custom_app_bar.dart';
+import 'package:app/ui/widget/custom_bottom_app_bar.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class ApplicationConfirmationScreen extends StatefulWidget {
+  static const route = '/applicationConfirmation';
+
+  ApplicationConfirmationScreen({Key? key}) : super(key: key);
+
+  @override
+  _ApplicationConfirmationScreenState createState() =>
+      _ApplicationConfirmationScreenState();
+}
+
+class _ApplicationConfirmationScreenState
+    extends State<ApplicationConfirmationScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return TemplateViewModel<ApplicationViewModel>(
+      builder: (context, model, _) => Scaffold(
+        appBar: customAppBar(
+            leftButtonText: "Account",
+            centreButtonText: "Home",
+            rightButtonText: "FAQ",
+            leftButtonAction: () {
+              // TODO
+            },
+            centreButtonAction: model.navigateToHomeScreen,
+            rightButtonAction: () {
+              // TODO
+            }),
+        bottomNavigationBar: CustomBottomAppBar.get(),
+        body: SingleChildScrollView(
+          child: Column(children: [
+            Container(
+                margin: EdgeInsets.all(20.0),
+                color: PersianGreenVeryOpaque,
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.all(20.0),
+                      child: Text(
+                        '''We are looking for people who will:
+              \n1. Help guide others in their search and answer their questions
+              \n2. Help us to organize and keep the application up to date
+              \n3. Help us to develop and evolve the application''',
+                        style: GoogleFonts.raleway(
+                          color: Charcoal,
+                          fontWeight: FontWeight.bold,
+                          fontSize: MediumTextSize,
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: EdgeInsets.all(20.0),
+                      child: Container(
+                        color: Colors.white,
+                        margin: EdgeInsets.all(10.0),
+                        padding: EdgeInsets.all(10.0),
+                        child: Text(
+                          '''If this sounds like you, please consider submitting an application''',
+                          textAlign: TextAlign.center,
+                          style: GoogleFonts.raleway(
+                            color: Charcoal,
+                            fontWeight: FontWeight.bold,
+                            fontSize: MediumTextSize,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                )),
+            elevatedButton(
+                text: "Yes! I want to help!",
+                onPressed: model.navigateToApplicationScreen,
+                color: PersianGreen,
+                pressedColor: PersianGreenOpaque),
+            Padding(
+              padding: EdgeInsets.all(20.0),
+              child: Text(
+                "If you choose \"yes\", an existing member of the team will review your posts and participation in the application to determine where you could best be placed on the team",
+                textAlign: TextAlign.center,
+                style: GoogleFonts.raleway(
+                  color: Charcoal,
+                  fontWeight: FontWeight.w300,
+                  fontSize: MediumTextSize,
+                ),
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.all(20.0),
+              child: Text(
+                "This process may take some time, please be patient with us!",
+                textAlign: TextAlign.center,
+                style: GoogleFonts.raleway(
+                  color: Charcoal,
+                  fontWeight: FontWeight.w300,
+                  fontSize: MediumTextSize,
+                ),
+              ),
+            ),
+          ]),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/screen/application_screen.dart
+++ b/app/lib/ui/screen/application_screen.dart
@@ -1,0 +1,116 @@
+import 'dart:ui';
+
+import 'package:app/core/thread.dart';
+import 'package:app/service/service_locator.dart';
+import 'package:app/ui/style.dart';
+import 'package:app/ui/view_model/application_screen_view_model.dart';
+import 'package:app/ui/view_model/specific_thread_view_model.dart';
+import 'package:app/ui/widget/custom_app_bar.dart';
+import 'package:app/ui/widget/custom_bottom_app_bar.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+import 'package:app/ui/widget/thread_preview_card.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:uuid/uuid.dart';
+
+class ApplicationScreen<T extends SpecificThreadViewModel>
+    extends StatefulWidget {
+  final _applicationScreenViewModel =
+      ServiceLocator.get<ApplicationViewModel>();
+  static const route = '/application';
+
+  ApplicationScreen({Key? key}) : super(key: key);
+
+  @override
+  _ApplicationScreenState<T> createState() => _ApplicationScreenState<T>();
+}
+
+class _ApplicationScreenState<T extends SpecificThreadViewModel>
+    extends State<ApplicationScreen<T>> {
+  ThreadPreviewCard createPreview(T model, Thread thread) => ThreadPreviewCard(
+      // Must have unique keys in rebuilding widget lists
+      key: ObjectKey(Uuid().v4()),
+      thread: thread,
+      onTap: () => model.navigateToThreadDisplayScreen(
+          thread: thread, isAnnouncement: false));
+
+  @override
+  Widget build(BuildContext context) {
+    return TemplateViewModel<T>(
+      builder: (context, model, _) => Scaffold(
+        appBar: customAppBar(
+            leftButtonText: "Account",
+            centreButtonText: "Home",
+            rightButtonText: "FAQ",
+            leftButtonAction: () {
+              // TODO
+            },
+            centreButtonAction: model.navigateToHomeScreen,
+            rightButtonAction: () {
+              // TODO
+            }),
+        bottomNavigationBar: CustomBottomAppBar.get(),
+        body: Column(children: [
+          Padding(
+            padding: EdgeInsets.all(20.0),
+            child: Text(
+              "A member of the existing team will review your questions and replies of yours to determinea good placement for you.",
+              style: GoogleFonts.raleway(
+                color: Charcoal,
+                fontSize: MediumTextSize,
+              ),
+            ),
+          ),
+          model.threads.isEmpty
+              ? Center(
+                  child: Container(
+                  margin: EdgeInsets.all(50.0),
+                  child: Card(
+                    child: ListTile(
+                      title: Text(
+                        "You have no questions yet",
+                        textAlign: TextAlign.center,
+                        style: TextStyle(fontSize: LargeTextSize),
+                      ),
+                    ),
+                  ),
+                ))
+              : Expanded(
+                  child: ListView.builder(
+                    itemCount: model.threads.length,
+                    itemBuilder: (context, index) =>
+                        createPreview(model, model.threads[index]),
+                  ),
+                ),
+          elevatedButton(
+              text: "Works for me!",
+              onPressed: widget._applicationScreenViewModel.sendApplication,
+              color: PersianGreen,
+              pressedColor: PersianGreenOpaque),
+          Padding(
+            padding: EdgeInsets.all(20.0),
+            child: Text(
+              "Team members will not contact you about the contents of your questions as part of the application process.",
+              style: GoogleFonts.raleway(
+                color: Charcoal,
+                fontWeight: FontWeight.w300,
+                fontSize: MediumTextSize,
+              ),
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.all(20.0),
+            child: Text(
+              "For further information about becoming a member of the team and associated responsibilities, please see the FAQ page.",
+              style: GoogleFonts.raleway(
+                color: Charcoal,
+                fontWeight: FontWeight.w300,
+                fontSize: MediumTextSize,
+              ),
+            ),
+          ),
+        ]),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/screen/home_screen.dart
+++ b/app/lib/ui/screen/home_screen.dart
@@ -195,10 +195,10 @@ class _HomeScreenState extends State<HomeScreen> {
         Padding(
           padding: EdgeInsets.only(bottom: 65.0),
         ),
-        elevatedButton(
-            text: "Would you like to help with this application?",
+        stretchedButton(
+            text: "Would you like to help with this app?",
             trailing: Icon(Icons.arrow_forward_ios_outlined),
-            onPressed: model.navigateToApplicationConsentScreen,
+            onPressed: model.navigateToApplicationConfirmationScreen,
             color: Charcoal,
             pressedColor: CharcoalOpaque),
       ],

--- a/app/lib/ui/screen/home_screen.dart
+++ b/app/lib/ui/screen/home_screen.dart
@@ -111,8 +111,11 @@ class _HomeScreenState extends State<HomeScreen> {
                                   onPressed: model.navigateToNewQuestionScreen,
                                   color: PersianGreen,
                                   pressedColor: PersianGreenOpaque),
+                              if (model.currentUserIsLoggedIn &&
+                                  !model.currentUserIsAdmin)
+                                _buildApplicationButton(model),
                               Padding(
-                                padding: EdgeInsets.only(bottom: 45.0),
+                                padding: EdgeInsets.only(bottom: 65.0),
                               ),
                               elevatedButton(
                                   text: "Logout (Temporary) ",
@@ -182,6 +185,22 @@ class _HomeScreenState extends State<HomeScreen> {
         Padding(
           padding: EdgeInsets.only(bottom: 15.0),
         ),
+      ],
+    );
+  }
+
+  Widget _buildApplicationButton(HomeViewModel model) {
+    return Column(
+      children: [
+        Padding(
+          padding: EdgeInsets.only(bottom: 65.0),
+        ),
+        elevatedButton(
+            text: "Would you like to help with this application?",
+            trailing: Icon(Icons.arrow_forward_ios_outlined),
+            onPressed: model.navigateToApplicationConsentScreen,
+            color: Charcoal,
+            pressedColor: CharcoalOpaque),
       ],
     );
   }

--- a/app/lib/ui/style.dart
+++ b/app/lib/ui/style.dart
@@ -12,6 +12,7 @@ final Charcoal = const Color.fromRGBO(38, 70, 83, 1);
 final CharcoalOpaque = const Color.fromRGBO(38, 70, 83, 50);
 final PersianGreen = const Color.fromRGBO(42, 157, 143, 1);
 final PersianGreenOpaque = const Color.fromRGBO(42, 157, 143, 50);
+final PersianGreenVeryOpaque = const Color.fromRGBO(35, 140, 125, 90);
 final OrangeYellowCrayola = const Color.fromRGBO(233, 196, 106, 1);
 final SandyBrown = const Color.fromRGBO(244, 162, 97, 1);
 final SandyBrownOpaque = const Color.fromRGBO(244, 162, 97, 50);

--- a/app/lib/ui/view_model/application_screen_view_model.dart
+++ b/app/lib/ui/view_model/application_screen_view_model.dart
@@ -9,6 +9,7 @@ import 'package:app/service/firestore_account_service.dart';
 import 'package:app/service/firestore_admin_service.dart';
 import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/application_screen.dart';
 import 'package:app/ui/screen/home_screen.dart';
 import 'package:app/ui/widget/template_view_model.dart';
 
@@ -30,7 +31,7 @@ class ApplicationViewModel extends ViewModel {
                   applicantId: account.id,
                   submissionDate: DateTime.now(),
                   approvalStatus: ApprovalStatus.nothing)))
-          .then((_) => _navigateToHomeScreen())
+          .then((_) => navigateToHomeScreen())
           .then((_) => _dialogService.showDialog(
               title: "Thank you for submitting a leadership application",
               description: "Please give us some time to respond"))
@@ -46,6 +47,9 @@ class ApplicationViewModel extends ViewModel {
     }
   }
 
-  void _navigateToHomeScreen() =>
+  void navigateToHomeScreen() =>
       _navigationService.navigateBackUntil(HomeScreen.route);
+
+  void navigateToApplicationScreen() =>
+      _navigationService.navigateTo(ApplicationScreen.route);
 }

--- a/app/lib/ui/view_model/application_screen_view_model.dart
+++ b/app/lib/ui/view_model/application_screen_view_model.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:app/core/account.dart';
+import 'package:app/core/administration_application.dart';
+import 'package:app/core/approval_status.dart';
+import 'package:app/service/dialog_service.dart';
+import 'package:app/service/firebase_auth_service.dart';
+import 'package:app/service/firestore_account_service.dart';
+import 'package:app/service/firestore_admin_service.dart';
+import 'package:app/service/navigation_service.dart';
+import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/home_screen.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+
+class ApplicationViewModel extends ViewModel {
+  final _navigationService = ServiceLocator.get<NavigationService>();
+  final _dialogService = ServiceLocator.get<DialogService>();
+  final _adminService = ServiceLocator.get<FirestoreAdminService>();
+  final _authenticationService = ServiceLocator.get<FirebaseAuthService>();
+  final _accountService = ServiceLocator.get<FirestoreAccountService>();
+
+  Future<void> sendApplication() {
+    final thisUser = _authenticationService.currentUser;
+    if (thisUser != null) {
+      return _accountService
+          .getAccount(thisUser.uid)
+          .then((Account account) => _adminService.addAdminApplication(
+              AdministrationApplication(
+                  applicantName: account.name,
+                  applicantId: account.id,
+                  submissionDate: DateTime.now(),
+                  approvalStatus: ApprovalStatus.nothing)))
+          .then((_) => _navigateToHomeScreen())
+          .then((_) => _dialogService.showDialog(
+              title: "Thank you for submitting a leadership application",
+              description: "Please give us some time to respond"))
+          .catchError((error) => _dialogService.showDialog(
+              title: "Could not submit a leadership application",
+              description:
+                  "Here's what we think went wrong\n${error.message}"));
+    } else {
+      _dialogService.showDialog(
+          title: "Could not submit a leadership application",
+          description: "You are not logged in!");
+      return Future.error("You are not logged in!");
+    }
+  }
+
+  void _navigateToHomeScreen() =>
+      _navigationService.navigateBackUntil(HomeScreen.route);
+}

--- a/app/lib/ui/view_model/home_view_model.dart
+++ b/app/lib/ui/view_model/home_view_model.dart
@@ -11,6 +11,7 @@ import 'package:app/service/firestore_thread_service.dart';
 import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/service/template_firestore_thread_service.dart';
+import 'package:app/ui/screen/application_screen.dart';
 import 'package:app/ui/screen/flagged_threads_screen.dart';
 import 'package:app/ui/screen/new_thread_screen.dart';
 import 'package:app/ui/screen/sign_up_screen.dart';
@@ -31,6 +32,7 @@ class HomeViewModel extends ViewModel {
   StreamSubscription<User?>? _currentUserSubscription;
   StreamSubscription<bool>? _currentUserIsAdminSubscription;
   late bool currentUserIsAdmin;
+  late bool currentUserIsLoggedIn;
   late Future<Thread> latestMyQuestion;
   late Future<Thread> latestAnnouncement;
 
@@ -44,11 +46,13 @@ class HomeViewModel extends ViewModel {
 
   HomeViewModel() {
     currentUserIsAdmin = _firebaseAuthService.currentUserIsAdmin;
+    currentUserIsLoggedIn = _firebaseAuthService.currentUser != null;
     _setLatestMyQuestion(_firebaseAuthService.currentUser);
     _setLatestAnnouncement();
     notifyListeners();
     _currentUserSubscription =
         _firebaseAuthService.currentUserChanges.listen((User? user) {
+      currentUserIsLoggedIn = user != null;
       _setLatestMyQuestion(user);
       notifyListeners();
     });
@@ -171,6 +175,9 @@ class HomeViewModel extends ViewModel {
 
   void navigateToThreadDisplayScreen(Thread thread) => _navigationService
       .navigateTo(ThreadDisplayScreen.route, arguments: thread);
+
+  void navigateToApplicationConsentScreen() =>
+      _navigationService.navigateTo(ApplicationScreen.route);
 
   void logOut() => _firebaseAuthService.signOut();
 }

--- a/app/lib/ui/view_model/home_view_model.dart
+++ b/app/lib/ui/view_model/home_view_model.dart
@@ -11,7 +11,7 @@ import 'package:app/service/firestore_thread_service.dart';
 import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/service/template_firestore_thread_service.dart';
-import 'package:app/ui/screen/application_screen.dart';
+import 'package:app/ui/screen/application_confirmation_screen.dart';
 import 'package:app/ui/screen/flagged_threads_screen.dart';
 import 'package:app/ui/screen/new_thread_screen.dart';
 import 'package:app/ui/screen/sign_up_screen.dart';
@@ -176,8 +176,8 @@ class HomeViewModel extends ViewModel {
   void navigateToThreadDisplayScreen(Thread thread) => _navigationService
       .navigateTo(ThreadDisplayScreen.route, arguments: thread);
 
-  void navigateToApplicationConsentScreen() =>
-      _navigationService.navigateTo(ApplicationScreen.route);
+  void navigateToApplicationConfirmationScreen() =>
+      _navigationService.navigateTo(ApplicationConfirmationScreen.route);
 
   void logOut() => _firebaseAuthService.signOut();
 }


### PR DESCRIPTION
Closes #67 .

This PR adds the two application screens: confirmation and submission, as per the prototype (and their VM).

***

Changes look like:

![Screen Shot 2021-04-02 at 7 46 51 PM](https://user-images.githubusercontent.com/32527219/113465680-4e9a4080-93f3-11eb-8b26-94a3d9eee957.png)
![Screen Shot 2021-04-02 at 8 35 49 PM](https://user-images.githubusercontent.com/32527219/113465683-4fcb6d80-93f3-11eb-91ff-d2b9db999f39.png)
![Screen Shot 2021-04-02 at 7 56 25 PM](https://user-images.githubusercontent.com/32527219/113465681-4f32d700-93f3-11eb-9d06-f5333855cf2c.png)
![Screen Shot 2021-04-02 at 8 15 29 PM](https://user-images.githubusercontent.com/32527219/113465682-4f32d700-93f3-11eb-9c62-0e9660f766d1.png)
