### PR TITLE
Add application review pages

### DIFF
--- a/app/lib/app_route_generator.dart
+++ b/app/lib/app_route_generator.dart
@@ -1,8 +1,10 @@
+import 'package:app/core/administration_application.dart';
 import 'package:app/core/thread.dart';
 import 'package:app/core/thread_type.dart';
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/ui/screen/application_confirmation_screen.dart';
+import 'package:app/ui/screen/application_review_screen.dart';
 import 'package:app/ui/screen/application_screen.dart';
 import 'package:app/ui/screen/flagged_threads_screen.dart';
 import 'package:app/ui/screen/home_screen.dart';
@@ -99,6 +101,15 @@ class AppRouteGenerator {
           case ApplicationScreen.route:
             if (isLoggedIn()) {
               return ApplicationScreen<MyQuestionsViewModel>();
+            } else {
+              throw Exception(
+                  'You must be logged in to view this screen: ${settings.name}');
+            }
+
+          case ApplicationReviewScreen.route:
+            if (isLoggedIn() && isAdmin()) {
+              return ApplicationReviewScreen(
+                  application: settings.arguments as AdministrationApplication);
             } else {
               throw Exception(
                   'You must be logged in to view this screen: ${settings.name}');

--- a/app/lib/app_route_generator.dart
+++ b/app/lib/app_route_generator.dart
@@ -6,6 +6,7 @@ import 'package:app/service/service_locator.dart';
 import 'package:app/ui/screen/application_confirmation_screen.dart';
 import 'package:app/ui/screen/application_review_screen.dart';
 import 'package:app/ui/screen/application_screen.dart';
+import 'package:app/ui/screen/applications_to_review_screen.dart';
 import 'package:app/ui/screen/flagged_threads_screen.dart';
 import 'package:app/ui/screen/home_screen.dart';
 import 'package:app/ui/screen/log_in_screen.dart';
@@ -101,6 +102,14 @@ class AppRouteGenerator {
           case ApplicationScreen.route:
             if (isLoggedIn()) {
               return ApplicationScreen<MyQuestionsViewModel>();
+            } else {
+              throw Exception(
+                  'You must be logged in to view this screen: ${settings.name}');
+            }
+
+          case ApplicationsToReviewScreen.route:
+            if (isLoggedIn() && isAdmin()) {
+              return ApplicationsToReviewScreen();
             } else {
               throw Exception(
                   'You must be logged in to view this screen: ${settings.name}');

--- a/app/lib/core/account.dart
+++ b/app/lib/core/account.dart
@@ -81,4 +81,12 @@ class Account {
       aboutMeDescription: newDescription,
       joinDate: joinDate,
       isAdmin: isAdmin);
+
+  Account asAdmin() => Account(
+      id: id,
+      name: name,
+      titles: titles,
+      aboutMeDescription: aboutMeDescription,
+      joinDate: joinDate,
+      isAdmin: true);
 }

--- a/app/lib/service/firestore_admin_service.dart
+++ b/app/lib/service/firestore_admin_service.dart
@@ -34,6 +34,16 @@ class FirestoreAdminService {
                       id: doc.id, json: doc.data()!))
               .toList());
 
+  Stream<AdministrationApplication> getUpdatedSpecificApplication(
+          AdministrationApplication application) =>
+      _firestore
+          .collection('adminApplication')
+          .doc(application.applicantId)
+          .snapshots()
+          .map((DocumentSnapshot snapshot) =>
+              AdministrationApplication.fromJson(
+                  id: snapshot.id, json: snapshot.data()!));
+
   Future<void> addThreadFlag(ThreadFlag threadFlag) async =>
       _firestore.collection('threadFlag').add(threadFlag.toJson());
 

--- a/app/lib/service/service_locator.dart
+++ b/app/lib/service/service_locator.dart
@@ -8,7 +8,7 @@ import 'package:app/service/navigation_service.dart';
 import 'package:app/ui/view_model/all_questions_view_model.dart';
 import 'package:app/ui/view_model/announcement_view_model.dart';
 import 'package:app/ui/view_model/announcements_view_model.dart';
-import 'package:app/ui/view_model/application_screen_view_model.dart';
+import 'package:app/ui/view_model/application_view_model.dart';
 import 'package:app/ui/view_model/flagged_threads_view_model.dart';
 import 'package:app/ui/view_model/home_view_model.dart';
 import 'package:app/ui/view_model/log_in_view_model.dart';

--- a/app/lib/service/service_locator.dart
+++ b/app/lib/service/service_locator.dart
@@ -9,6 +9,7 @@ import 'package:app/ui/view_model/all_questions_view_model.dart';
 import 'package:app/ui/view_model/announcement_view_model.dart';
 import 'package:app/ui/view_model/announcements_view_model.dart';
 import 'package:app/ui/view_model/application_view_model.dart';
+import 'package:app/ui/view_model/applications_to_review_view_model.dart';
 import 'package:app/ui/view_model/flagged_threads_view_model.dart';
 import 'package:app/ui/view_model/home_view_model.dart';
 import 'package:app/ui/view_model/log_in_view_model.dart';
@@ -54,5 +55,7 @@ class ServiceLocator {
     get.registerFactory<FlaggedThreadsViewModel>(
         () => FlaggedThreadsViewModel());
     get.registerFactory<ApplicationViewModel>(() => ApplicationViewModel());
+    get.registerFactory<ApplicationsToReviewViewModel>(
+        () => ApplicationsToReviewViewModel());
   }
 }

--- a/app/lib/ui/screen/application_confirmation_screen.dart
+++ b/app/lib/ui/screen/application_confirmation_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
 import 'package:app/ui/style.dart';
-import 'package:app/ui/view_model/application_screen_view_model.dart';
+import 'package:app/ui/view_model/application_view_model.dart';
 import 'package:app/ui/widget/custom_app_bar.dart';
 import 'package:app/ui/widget/custom_bottom_app_bar.dart';
 import 'package:app/ui/widget/template_view_model.dart';

--- a/app/lib/ui/screen/application_review_screen.dart
+++ b/app/lib/ui/screen/application_review_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:app/core/administration_application.dart';
 import 'package:app/core/thread.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/ui/style.dart';
@@ -13,20 +14,23 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:uuid/uuid.dart';
 
-class ApplicationScreen<T extends SpecificThreadViewModel>
+class ApplicationReviewScreen<T extends SpecificThreadViewModel>
     extends StatefulWidget {
   final _applicationScreenViewModel =
       ServiceLocator.get<ApplicationViewModel>();
-  static const route = '/application';
+  static const route = '/applicationReview';
+  final AdministrationApplication application;
 
-  ApplicationScreen({Key? key}) : super(key: key);
+  ApplicationReviewScreen({Key? key, required this.application})
+      : super(key: key);
 
   @override
-  _ApplicationScreenState<T> createState() => _ApplicationScreenState<T>();
+  _ApplicationReviewScreenState<T> createState() =>
+      _ApplicationReviewScreenState<T>();
 }
 
-class _ApplicationScreenState<T extends SpecificThreadViewModel>
-    extends State<ApplicationScreen<T>> {
+class _ApplicationReviewScreenState<T extends SpecificThreadViewModel>
+    extends State<ApplicationReviewScreen<T>> {
   ThreadPreviewCard createPreview(T model, Thread thread) => ThreadPreviewCard(
       // Must have unique keys in rebuilding widget lists
       key: ObjectKey(Uuid().v4()),
@@ -54,7 +58,8 @@ class _ApplicationScreenState<T extends SpecificThreadViewModel>
           Padding(
             padding: EdgeInsets.all(20.0),
             child: Text(
-              "A member of the existing team will review your questions and replies of yours to determinea good placement for you.",
+              '''Review ${widget.application.applicantName}'s application to become a member of the leadership team
+              \nHere's their content so far:''',
               style: GoogleFonts.raleway(
                 color: Charcoal,
                 fontSize: MediumTextSize,
@@ -68,7 +73,7 @@ class _ApplicationScreenState<T extends SpecificThreadViewModel>
                   child: Card(
                     child: ListTile(
                       title: Text(
-                        "You have no questions yet",
+                        "There are no questions yet",
                         textAlign: TextAlign.center,
                         style: TextStyle(fontSize: LargeTextSize),
                       ),
@@ -82,32 +87,25 @@ class _ApplicationScreenState<T extends SpecificThreadViewModel>
                         createPreview(model, model.threads[index]),
                   ),
                 ),
-          elevatedButton(
-              text: "Works for me!",
-              onPressed: widget._applicationScreenViewModel.sendApplication,
-              color: PersianGreen,
-              pressedColor: PersianGreenOpaque),
-          Padding(
-            padding: EdgeInsets.all(20.0),
-            child: Text(
-              "Team members will not contact you about the contents of your questions as part of the application process.",
-              style: GoogleFonts.raleway(
-                color: Charcoal,
-                fontWeight: FontWeight.w300,
-                fontSize: MediumTextSize,
-              ),
-            ),
+          Align(
+            alignment: Alignment.topLeft,
+            child: outlinedButton(
+                text: "Not a good fit yet",
+                onPressed: () => widget._applicationScreenViewModel
+                    .denyApplication(widget.application),
+                color: Charcoal),
           ),
           Padding(
-            padding: EdgeInsets.all(20.0),
-            child: Text(
-              "For further information about becoming a member of the team and associated responsibilities, please see the FAQ page.",
-              style: GoogleFonts.raleway(
-                color: Charcoal,
-                fontWeight: FontWeight.w300,
-                fontSize: MediumTextSize,
-              ),
-            ),
+            padding: EdgeInsets.all(65.0),
+          ),
+          Align(
+            alignment: Alignment.bottomRight,
+            child: elevatedButton(
+                text: "Yes! They should join the team!",
+                onPressed: () => widget._applicationScreenViewModel
+                    .approveApplication(widget.application),
+                color: PersianGreen,
+                pressedColor: PersianGreenOpaque),
           ),
         ]),
       ),

--- a/app/lib/ui/screen/application_review_screen.dart
+++ b/app/lib/ui/screen/application_review_screen.dart
@@ -2,22 +2,26 @@ import 'dart:ui';
 
 import 'package:app/core/administration_application.dart';
 import 'package:app/core/thread.dart';
+import 'package:app/service/dialog_service.dart';
+import 'package:app/service/firestore_thread_service.dart';
+import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/thread_display_screen.dart';
 import 'package:app/ui/style.dart';
 import 'package:app/ui/view_model/application_view_model.dart';
-import 'package:app/ui/view_model/specific_thread_view_model.dart';
 import 'package:app/ui/widget/custom_app_bar.dart';
 import 'package:app/ui/widget/custom_bottom_app_bar.dart';
-import 'package:app/ui/widget/template_view_model.dart';
 import 'package:app/ui/widget/thread_preview_card.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:uuid/uuid.dart';
 
-class ApplicationReviewScreen<T extends SpecificThreadViewModel>
-    extends StatefulWidget {
-  final _applicationScreenViewModel =
-      ServiceLocator.get<ApplicationViewModel>();
+class ApplicationReviewScreen extends StatefulWidget {
+  final _applicationViewModel = ServiceLocator.get<ApplicationViewModel>();
+  final _navigationService = ServiceLocator.get<NavigationService>();
+  final _threadService = ServiceLocator.get<FirestoreThreadService>();
+  final _dialogService = ServiceLocator.get<DialogService>();
+
   static const route = '/applicationReview';
   final AdministrationApplication application;
 
@@ -25,90 +29,124 @@ class ApplicationReviewScreen<T extends SpecificThreadViewModel>
       : super(key: key);
 
   @override
-  _ApplicationReviewScreenState<T> createState() =>
-      _ApplicationReviewScreenState<T>();
+  _ApplicationReviewScreenState createState() =>
+      _ApplicationReviewScreenState();
 }
 
-class _ApplicationReviewScreenState<T extends SpecificThreadViewModel>
-    extends State<ApplicationReviewScreen<T>> {
-  ThreadPreviewCard createPreview(T model, Thread thread) => ThreadPreviewCard(
+class _ApplicationReviewScreenState extends State<ApplicationReviewScreen> {
+  ThreadPreviewCard createPreview(Thread thread) => ThreadPreviewCard(
       // Must have unique keys in rebuilding widget lists
       key: ObjectKey(Uuid().v4()),
       thread: thread,
-      onTap: () => model.navigateToThreadDisplayScreen(
-          thread: thread, isAnnouncement: false));
+      onTap: () => widget._navigationService
+          .navigateTo(ThreadDisplayScreen.route, arguments: thread));
 
   @override
   Widget build(BuildContext context) {
-    return TemplateViewModel<T>(
-      builder: (context, model, _) => Scaffold(
-        appBar: customAppBar(
-            leftButtonText: "Account",
-            centreButtonText: "Home",
-            rightButtonText: "FAQ",
-            leftButtonAction: () {
-              // TODO
-            },
-            centreButtonAction: model.navigateToHomeScreen,
-            rightButtonAction: () {
-              // TODO
-            }),
-        bottomNavigationBar: CustomBottomAppBar.get(),
-        body: Column(children: [
-          Padding(
-            padding: EdgeInsets.all(20.0),
-            child: Text(
-              '''Review ${widget.application.applicantName}'s application to become a member of the leadership team
+    // TODO: Move this stream into ViewModel. Need to give the VM the initial account
+    // Unfortunately, this widget and it's behaviour are tightly coupled to the
+    // database service such that a view model cannot be between as the design
+    // is now (requires a given Account to start)
+    return StreamBuilder<List<Thread>>(
+        stream: widget._threadService
+            .getUpdatedAccountSpecificThreads(widget.application.applicantId),
+        builder: (BuildContext context, AsyncSnapshot<List<Thread>> snapshot) {
+          List<Widget> children = [];
+          if (snapshot.hasData) {
+            children.add(_buildReviewScreen(snapshot.data!));
+          } else if (snapshot.hasError) {
+            children.add(outlinedBox(
+                child: Text("There is no information to show"),
+                childAlignmentInBox: Alignment.centerLeft,
+                color: Colors.red));
+            widget._dialogService.showDialog(
+              title: 'Getting information for you failed!',
+              description:
+                  "Here's what we think went wrong:\n${snapshot.error.toString()}",
+            );
+          } else {
+            children.add(outlinedBox(
+                child: CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation(PersianGreen)),
+                childAlignmentInBox: Alignment.center,
+                color: PersianGreen));
+          }
+          return Scaffold(
+              appBar: customAppBar(
+                  leftButtonText: "Account",
+                  centreButtonText: "Home",
+                  rightButtonText: "FAQ",
+                  leftButtonAction: () {
+                    // TODO
+                  },
+                  centreButtonAction: () =>
+                      widget._applicationViewModel.navigateToHomeScreen(),
+                  rightButtonAction: () {
+                    // TODO
+                  }),
+              bottomNavigationBar: CustomBottomAppBar.get(),
+              body: SingleChildScrollView(child: Column(children: children)));
+        });
+  }
+
+  Widget _buildReviewScreen(List<Thread> threads) {
+    return Column(children: [
+      Padding(
+        padding: EdgeInsets.all(20.0),
+        child: Text(
+          '''Review ${widget.application.applicantName}'s application to become a member of the leadership team
               \nHere's their content so far:''',
-              style: GoogleFonts.raleway(
-                color: Charcoal,
-                fontSize: MediumTextSize,
-              ),
-            ),
+          style: GoogleFonts.raleway(
+            color: Charcoal,
+            fontSize: MediumTextSize,
           ),
-          model.threads.isEmpty
-              ? Center(
-                  child: Container(
-                  margin: EdgeInsets.all(50.0),
-                  child: Card(
-                    child: ListTile(
-                      title: Text(
-                        "There are no questions yet",
-                        textAlign: TextAlign.center,
-                        style: TextStyle(fontSize: LargeTextSize),
-                      ),
-                    ),
-                  ),
-                ))
-              : Expanded(
-                  child: ListView.builder(
-                    itemCount: model.threads.length,
-                    itemBuilder: (context, index) =>
-                        createPreview(model, model.threads[index]),
+        ),
+      ),
+      threads.isEmpty
+          ? Center(
+              child: Container(
+              margin: EdgeInsets.all(50.0),
+              child: Card(
+                child: ListTile(
+                  title: Text(
+                    "There are no questions yet",
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontSize: LargeTextSize),
                   ),
                 ),
-          Align(
-            alignment: Alignment.topLeft,
+              ),
+            ))
+          : Column(
+              children: List<ThreadPreviewCard>.generate(
+                  threads.length, (index) => createPreview(threads[index])),
+            ),
+      Padding(
+        padding: EdgeInsets.only(bottom: 10.0),
+      ),
+      Align(
+          alignment: Alignment.topLeft,
+          child: Padding(
+            padding: EdgeInsets.all(5.0),
             child: outlinedButton(
                 text: "Not a good fit yet",
-                onPressed: () => widget._applicationScreenViewModel
+                onPressed: () => widget._applicationViewModel
                     .denyApplication(widget.application),
                 color: Charcoal),
-          ),
-          Padding(
-            padding: EdgeInsets.all(65.0),
-          ),
-          Align(
-            alignment: Alignment.bottomRight,
+          )),
+      Padding(
+        padding: EdgeInsets.all(25.0),
+      ),
+      Align(
+          alignment: Alignment.bottomRight,
+          child: Padding(
+            padding: EdgeInsets.all(5.0),
             child: elevatedButton(
                 text: "Yes! They should join the team!",
-                onPressed: () => widget._applicationScreenViewModel
+                onPressed: () => widget._applicationViewModel
                     .approveApplication(widget.application),
                 color: PersianGreen,
                 pressedColor: PersianGreenOpaque),
-          ),
-        ]),
-      ),
-    );
+          )),
+    ]);
   }
 }

--- a/app/lib/ui/screen/application_review_screen.dart
+++ b/app/lib/ui/screen/application_review_screen.dart
@@ -91,16 +91,36 @@ class _ApplicationReviewScreenState extends State<ApplicationReviewScreen> {
 
   Widget _buildReviewScreen(List<Thread> threads) {
     return Column(children: [
-      Padding(
-        padding: EdgeInsets.all(20.0),
-        child: Text(
-          '''Review ${widget.application.applicantName}'s application to become a member of the leadership team
-              \nHere's their content so far:''',
-          style: GoogleFonts.raleway(
-            color: Charcoal,
-            fontSize: MediumTextSize,
+      Container(
+        margin: EdgeInsets.all(20.0),
+        color: PersianGreenVeryOpaque,
+        child: Column(children: [
+          Container(
+            color: Colors.white,
+            margin: EdgeInsets.all(10.0),
+            padding: EdgeInsets.all(10.0),
+            child: Text(
+              "Review ${widget.application.applicantName}'s application to become a member of the leadership team",
+              textAlign: TextAlign.center,
+              style: GoogleFonts.raleway(
+                color: Charcoal,
+                fontWeight: FontWeight.bold,
+                fontSize: MediumTextSize,
+              ),
+            ),
           ),
-        ),
+          Padding(
+            padding: EdgeInsets.all(20.0),
+            child: Text(
+              "Here's their content so far",
+              style: GoogleFonts.raleway(
+                color: Charcoal,
+                fontWeight: FontWeight.bold,
+                fontSize: MediumTextSize,
+              ),
+            ),
+          ),
+        ]),
       ),
       threads.isEmpty
           ? Center(
@@ -121,7 +141,7 @@ class _ApplicationReviewScreenState extends State<ApplicationReviewScreen> {
                   threads.length, (index) => createPreview(threads[index])),
             ),
       Padding(
-        padding: EdgeInsets.only(bottom: 10.0),
+        padding: EdgeInsets.only(bottom: 15.0),
       ),
       Align(
           alignment: Alignment.topLeft,
@@ -134,7 +154,7 @@ class _ApplicationReviewScreenState extends State<ApplicationReviewScreen> {
                 color: Charcoal),
           )),
       Padding(
-        padding: EdgeInsets.all(25.0),
+        padding: EdgeInsets.all(20.0),
       ),
       Align(
           alignment: Alignment.bottomRight,

--- a/app/lib/ui/screen/application_screen.dart
+++ b/app/lib/ui/screen/application_screen.dart
@@ -4,7 +4,7 @@ import 'package:app/core/thread.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/ui/style.dart';
 import 'package:app/ui/view_model/application_view_model.dart';
-import 'package:app/ui/view_model/specific_thread_view_model.dart';
+import 'package:app/ui/view_model/specific_item_view_model.dart';
 import 'package:app/ui/widget/custom_app_bar.dart';
 import 'package:app/ui/widget/custom_bottom_app_bar.dart';
 import 'package:app/ui/widget/template_view_model.dart';
@@ -13,7 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:uuid/uuid.dart';
 
-class ApplicationScreen<T extends SpecificThreadViewModel>
+class ApplicationScreen<T extends SpecificItemViewModel>
     extends StatefulWidget {
   final _applicationScreenViewModel =
       ServiceLocator.get<ApplicationViewModel>();
@@ -25,14 +25,13 @@ class ApplicationScreen<T extends SpecificThreadViewModel>
   _ApplicationScreenState<T> createState() => _ApplicationScreenState<T>();
 }
 
-class _ApplicationScreenState<T extends SpecificThreadViewModel>
+class _ApplicationScreenState<T extends SpecificItemViewModel>
     extends State<ApplicationScreen<T>> {
   ThreadPreviewCard createPreview(T model, Thread thread) => ThreadPreviewCard(
       // Must have unique keys in rebuilding widget lists
       key: ObjectKey(Uuid().v4()),
       thread: thread,
-      onTap: () => model.navigateToThreadDisplayScreen(
-          thread: thread, isAnnouncement: false));
+      onTap: () => model.navigateToThreadDisplayScreen(thread));
 
   @override
   Widget build(BuildContext context) {
@@ -61,7 +60,7 @@ class _ApplicationScreenState<T extends SpecificThreadViewModel>
               ),
             ),
           ),
-          model.threads.isEmpty
+          model.items.isEmpty
               ? Center(
                   child: Container(
                   margin: EdgeInsets.all(50.0),
@@ -77,9 +76,9 @@ class _ApplicationScreenState<T extends SpecificThreadViewModel>
                 ))
               : Expanded(
                   child: ListView.builder(
-                    itemCount: model.threads.length,
+                    itemCount: model.items.length,
                     itemBuilder: (context, index) =>
-                        createPreview(model, model.threads[index]),
+                        createPreview(model, model.items[index]),
                   ),
                 ),
           elevatedButton(

--- a/app/lib/ui/screen/applications_to_review_screen.dart
+++ b/app/lib/ui/screen/applications_to_review_screen.dart
@@ -1,37 +1,35 @@
-import 'package:app/core/thread.dart';
+import 'package:app/core/administration_application.dart';
 import 'package:app/ui/style.dart';
-import 'package:app/ui/view_model/specific_item_view_model.dart';
+import 'package:app/ui/view_model/applications_to_review_view_model.dart';
+import 'package:app/ui/widget/application_preview_card.dart';
 import 'package:app/ui/widget/custom_app_bar.dart';
 import 'package:app/ui/widget/custom_bottom_app_bar.dart';
 import 'package:app/ui/widget/template_view_model.dart';
-import 'package:app/ui/widget/thread_preview_card.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
-class SpecificThreadsScreen<T extends SpecificItemViewModel>
-    extends StatefulWidget {
-  final bool isAnnouncements;
-  static const route = '/specificThreads';
+class ApplicationsToReviewScreen extends StatefulWidget {
+  static const route = '/applicationsToReview';
 
-  const SpecificThreadsScreen({Key? key, required this.isAnnouncements})
-      : super(key: key);
+  const ApplicationsToReviewScreen({Key? key}) : super(key: key);
 
   @override
-  _SpecificThreadsScreenState<T> createState() =>
-      _SpecificThreadsScreenState<T>();
+  _ApplicationsToReviewScreenState createState() =>
+      _ApplicationsToReviewScreenState();
 }
 
-class _SpecificThreadsScreenState<T extends SpecificItemViewModel>
-    extends State<SpecificThreadsScreen<T>> {
-  ThreadPreviewCard createPreview(T model, Thread thread) => ThreadPreviewCard(
-      // Must have unique keys in rebuilding widget lists
-      key: ObjectKey(Uuid().v4()),
-      thread: thread,
-      onTap: () => model.navigateToThreadDisplayScreen(thread));
+class _ApplicationsToReviewScreenState
+    extends State<ApplicationsToReviewScreen> {
+  ApplicationPreviewCard createPreview(AdministrationApplication application) =>
+      ApplicationPreviewCard(
+        // Must have unique keys in rebuilding widget lists
+        key: ObjectKey(Uuid().v4()),
+        application: application,
+      );
 
   @override
   Widget build(BuildContext context) {
-    return TemplateViewModel<T>(
+    return TemplateViewModel<ApplicationsToReviewViewModel>(
       builder: (context, model, _) => Scaffold(
         appBar: customAppBar(
             leftButtonText: "Account",
@@ -62,7 +60,7 @@ class _SpecificThreadsScreenState<T extends SpecificItemViewModel>
             : ListView.builder(
                 itemCount: model.items.length,
                 itemBuilder: (context, index) =>
-                    createPreview(model, model.items[index]),
+                    createPreview(model.items[index]),
               ),
       ),
     );

--- a/app/lib/ui/screen/flagged_threads_screen.dart
+++ b/app/lib/ui/screen/flagged_threads_screen.dart
@@ -1,6 +1,6 @@
 import 'package:app/core/thread_flag.dart';
 import 'package:app/ui/style.dart';
-import 'package:app/ui/view_model/specific_thread_view_model.dart';
+import 'package:app/ui/view_model/specific_item_view_model.dart';
 import 'package:app/ui/widget/custom_app_bar.dart';
 import 'package:app/ui/widget/custom_bottom_app_bar.dart';
 import 'package:app/ui/widget/flagged_thread_preview_card.dart';
@@ -8,7 +8,7 @@ import 'package:app/ui/widget/template_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:uuid/uuid.dart';
 
-class FlaggedThreadsScreen<T extends SpecificThreadViewModel>
+class FlaggedThreadsScreen<T extends SpecificItemViewModel>
     extends StatefulWidget {
   static const route = '/flaggedThreads';
 
@@ -19,9 +19,9 @@ class FlaggedThreadsScreen<T extends SpecificThreadViewModel>
       _FlaggedThreadsScreenState<T>();
 }
 
-class _FlaggedThreadsScreenState<T extends SpecificThreadViewModel>
+class _FlaggedThreadsScreenState<T extends SpecificItemViewModel>
     extends State<FlaggedThreadsScreen<T>> {
-  FlaggedThreadPreviewCard createPreview(T model, ThreadFlag threadFlag) =>
+  FlaggedThreadPreviewCard createPreview(ThreadFlag threadFlag) =>
       FlaggedThreadPreviewCard(
         // Must have unique keys in rebuilding widget lists
         key: ObjectKey(Uuid().v4()),
@@ -44,7 +44,7 @@ class _FlaggedThreadsScreenState<T extends SpecificThreadViewModel>
               // TODO
             }),
         bottomNavigationBar: CustomBottomAppBar.get(),
-        body: model.threads.isEmpty
+        body: model.items.isEmpty
             ? Center(
                 child: Container(
                 margin: EdgeInsets.all(50.0),
@@ -59,9 +59,9 @@ class _FlaggedThreadsScreenState<T extends SpecificThreadViewModel>
                 ),
               ))
             : ListView.builder(
-                itemCount: model.threads.length,
+                itemCount: model.items.length,
                 itemBuilder: (context, index) =>
-                    createPreview(model, model.threads[index]),
+                    createPreview(model.items[index]),
               ),
       ),
     );

--- a/app/lib/ui/screen/home_screen.dart
+++ b/app/lib/ui/screen/home_screen.dart
@@ -48,6 +48,8 @@ class _HomeScreenState extends State<HomeScreen> {
                             children: [
                               if (model.currentUserIsAdmin)
                                 _buildCallsForReviewButton(model),
+                              if (model.currentUserIsAdmin)
+                                _buildReviewApplicationsButton(model),
                               stretchedButton(
                                   text: "All Questions",
                                   trailing:
@@ -180,8 +182,8 @@ class _HomeScreenState extends State<HomeScreen> {
             text: "Calls for question reviews",
             trailing: Icon(Icons.arrow_forward_ios_outlined),
             onPressed: model.navigateToFlaggedThreadsScreen,
-            color: BurntSienna,
-            pressedColor: BurntSiennaOpaque),
+            color: PersianGreen,
+            pressedColor: PersianGreenOpaque),
         Padding(
           padding: EdgeInsets.only(bottom: 15.0),
         ),
@@ -201,6 +203,22 @@ class _HomeScreenState extends State<HomeScreen> {
             onPressed: model.navigateToApplicationConfirmationScreen,
             color: Charcoal,
             pressedColor: CharcoalOpaque),
+      ],
+    );
+  }
+
+  Widget _buildReviewApplicationsButton(HomeViewModel model) {
+    return Column(
+      children: [
+        stretchedButton(
+            text: "Review admin applications",
+            trailing: Icon(Icons.arrow_forward_ios_outlined),
+            onPressed: model.navigateToApplicationsToReviewScreen,
+            color: BurntSienna,
+            pressedColor: BurntSiennaOpaque),
+        Padding(
+          padding: EdgeInsets.only(bottom: 15.0),
+        ),
       ],
     );
   }

--- a/app/lib/ui/view_model/all_questions_view_model.dart
+++ b/app/lib/ui/view_model/all_questions_view_model.dart
@@ -3,10 +3,10 @@ import 'dart:async';
 import 'package:app/core/thread.dart';
 import 'package:app/service/firestore_thread_service.dart';
 import 'package:app/service/service_locator.dart';
-import 'package:app/ui/view_model/specific_thread_view_model.dart';
+import 'package:app/ui/view_model/specific_item_view_model.dart';
 import 'package:flutter/foundation.dart';
 
-class AllQuestionsViewModel extends SpecificThreadViewModel<Thread> {
+class AllQuestionsViewModel extends SpecificItemViewModel<Thread> {
   final _threadService = ServiceLocator.get<FirestoreThreadService>();
   StreamSubscription<List<Thread>>? _questionsSubscription;
 

--- a/app/lib/ui/view_model/announcements_view_model.dart
+++ b/app/lib/ui/view_model/announcements_view_model.dart
@@ -3,10 +3,10 @@ import 'dart:async';
 import 'package:app/core/thread.dart';
 import 'package:app/service/firestore_announcement_service.dart';
 import 'package:app/service/service_locator.dart';
-import 'package:app/ui/view_model/specific_thread_view_model.dart';
+import 'package:app/ui/view_model/specific_item_view_model.dart';
 import 'package:flutter/foundation.dart';
 
-class AnnouncementsViewModel extends SpecificThreadViewModel<Thread> {
+class AnnouncementsViewModel extends SpecificItemViewModel<Thread> {
   final _announcementService =
       ServiceLocator.get<FirestoreAnnouncementService>();
   StreamSubscription<List<Thread>>? _announcementsSubscription;

--- a/app/lib/ui/view_model/application_view_model.dart
+++ b/app/lib/ui/view_model/application_view_model.dart
@@ -10,6 +10,7 @@ import 'package:app/service/firestore_admin_service.dart';
 import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/ui/screen/application_screen.dart';
+import 'package:app/ui/screen/applications_to_review_screen.dart';
 import 'package:app/ui/screen/home_screen.dart';
 import 'package:app/ui/widget/template_view_model.dart';
 
@@ -70,9 +71,8 @@ class ApplicationViewModel extends ViewModel {
               description:
                   "Here's what we think went wrong:\n${error.message}"));
 
-  void navigateToApplicationsToReviewScreen() {
-    // TODO
-  }
+  void navigateToApplicationsToReviewScreen() =>
+      _navigationService.navigateBackUntil(ApplicationsToReviewScreen.route);
 
   void navigateToHomeScreen() =>
       _navigationService.navigateBackUntil(HomeScreen.route);

--- a/app/lib/ui/view_model/application_view_model.dart
+++ b/app/lib/ui/view_model/application_view_model.dart
@@ -47,6 +47,33 @@ class ApplicationViewModel extends ViewModel {
     }
   }
 
+  Future<void> approveApplication(AdministrationApplication application) =>
+      _accountService
+          .getAccount(application.applicantId)
+          .then((Account account) =>
+              _accountService.updateAccount(account.asAdmin()))
+          .then((_) => _adminService.updateAdminApplication(
+              application.withApprovalStatus(ApprovalStatus.approved)))
+          .then((_) => navigateToApplicationsToReviewScreen())
+          .catchError((error) => _dialogService.showDialog(
+              title: "Could not complete approval of the application",
+              description:
+                  "Here's what we think went wrong:\n${error.message}"));
+
+  Future<void> denyApplication(AdministrationApplication application) =>
+      _adminService
+          .updateAdminApplication(
+              application.withApprovalStatus(ApprovalStatus.denied))
+          .then((_) => navigateToApplicationsToReviewScreen())
+          .catchError((error) => _dialogService.showDialog(
+              title: "Could not complete updating the application",
+              description:
+                  "Here's what we think went wrong:\n${error.message}"));
+
+  void navigateToApplicationsToReviewScreen() {
+    // TODO
+  }
+
   void navigateToHomeScreen() =>
       _navigationService.navigateBackUntil(HomeScreen.route);
 

--- a/app/lib/ui/view_model/applications_to_review_view_model.dart
+++ b/app/lib/ui/view_model/applications_to_review_view_model.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:app/core/administration_application.dart';
+import 'package:app/service/firestore_admin_service.dart';
+import 'package:app/service/service_locator.dart';
+import 'package:app/ui/view_model/specific_item_view_model.dart';
+import 'package:flutter/foundation.dart';
+
+class ApplicationsToReviewViewModel
+    extends SpecificItemViewModel<AdministrationApplication> {
+  final _adminService = ServiceLocator.get<FirestoreAdminService>();
+  StreamSubscription<List<AdministrationApplication>>?
+      _applicationsSubscription;
+
+  @mustCallSuper
+  void dispose() {
+    removeAll();
+    if (_applicationsSubscription != null) _applicationsSubscription!.cancel();
+    super.dispose();
+  }
+
+  ApplicationsToReviewViewModel() {
+    _applicationsSubscription = _adminService
+        .getAllUpdatedAdminApplications()
+        .listen((List<AdministrationApplication> applications) {
+      removeAll();
+      addAll(applications);
+    });
+  }
+}

--- a/app/lib/ui/view_model/flagged_threads_view_model.dart
+++ b/app/lib/ui/view_model/flagged_threads_view_model.dart
@@ -3,10 +3,10 @@ import 'dart:async';
 import 'package:app/core/thread_flag.dart';
 import 'package:app/service/firestore_admin_service.dart';
 import 'package:app/service/service_locator.dart';
-import 'package:app/ui/view_model/specific_thread_view_model.dart';
+import 'package:app/ui/view_model/specific_item_view_model.dart';
 import 'package:flutter/foundation.dart';
 
-class FlaggedThreadsViewModel extends SpecificThreadViewModel<ThreadFlag> {
+class FlaggedThreadsViewModel extends SpecificItemViewModel<ThreadFlag> {
   final _adminService = ServiceLocator.get<FirestoreAdminService>();
   StreamSubscription<List<ThreadFlag>>? _flaggedThreadsSubscription;
 

--- a/app/lib/ui/view_model/home_view_model.dart
+++ b/app/lib/ui/view_model/home_view_model.dart
@@ -12,6 +12,7 @@ import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/service/template_firestore_thread_service.dart';
 import 'package:app/ui/screen/application_confirmation_screen.dart';
+import 'package:app/ui/screen/applications_to_review_screen.dart';
 import 'package:app/ui/screen/flagged_threads_screen.dart';
 import 'package:app/ui/screen/new_thread_screen.dart';
 import 'package:app/ui/screen/sign_up_screen.dart';
@@ -178,6 +179,9 @@ class HomeViewModel extends ViewModel {
 
   void navigateToApplicationConfirmationScreen() =>
       _navigationService.navigateTo(ApplicationConfirmationScreen.route);
+
+  void navigateToApplicationsToReviewScreen() =>
+      _navigationService.navigateTo(ApplicationsToReviewScreen.route);
 
   void logOut() => _firebaseAuthService.signOut();
 }

--- a/app/lib/ui/view_model/my_questions_view_model.dart
+++ b/app/lib/ui/view_model/my_questions_view_model.dart
@@ -5,11 +5,11 @@ import 'package:app/service/dialog_service.dart';
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/firestore_thread_service.dart';
 import 'package:app/service/service_locator.dart';
-import 'package:app/ui/view_model/specific_thread_view_model.dart';
+import 'package:app/ui/view_model/specific_item_view_model.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
-class MyQuestionsViewModel extends SpecificThreadViewModel<Thread> {
+class MyQuestionsViewModel extends SpecificItemViewModel<Thread> {
   final _threadService = ServiceLocator.get<FirestoreThreadService>();
   final _dialogService = ServiceLocator.get<DialogService>();
   final _firebaseAuthService = ServiceLocator.get<FirebaseAuthService>();

--- a/app/lib/ui/view_model/specific_item_view_model.dart
+++ b/app/lib/ui/view_model/specific_item_view_model.dart
@@ -5,24 +5,23 @@ import 'package:app/ui/screen/home_screen.dart';
 import 'package:app/ui/screen/thread_display_screen.dart';
 import 'package:app/ui/widget/template_view_model.dart';
 
-abstract class SpecificThreadViewModel<T> extends ViewModel {
+abstract class SpecificItemViewModel<T> extends ViewModel {
   final _navigationService = ServiceLocator.get<NavigationService>();
-  final List<T> _threads = [];
+  final List<T> _items = [];
 
-  List<T> get threads => List.unmodifiable(_threads);
+  List<T> get items => List.unmodifiable(_items);
 
   void addAll(List<T> threads) {
-    _threads.addAll(threads);
+    _items.addAll(threads);
     notifyListeners();
   }
 
   void removeAll() {
-    _threads.clear();
+    _items.clear();
     notifyListeners();
   }
 
-  void navigateToThreadDisplayScreen(
-      {required Thread thread, required bool isAnnouncement}) {
+  void navigateToThreadDisplayScreen(Thread thread) {
     _navigationService.navigateTo(ThreadDisplayScreen.route, arguments: thread);
   }
 

--- a/app/lib/ui/widget/application_preview_card.dart
+++ b/app/lib/ui/widget/application_preview_card.dart
@@ -1,0 +1,94 @@
+import 'package:app/core/administration_application.dart';
+import 'package:app/core/approval_status.dart';
+import 'package:app/service/firestore_admin_service.dart';
+import 'package:app/service/navigation_service.dart';
+import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/application_review_screen.dart';
+import 'package:app/ui/style.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class ApplicationPreviewCard extends StatefulWidget {
+  final _adminService = ServiceLocator.get<FirestoreAdminService>();
+  final _navigationService = ServiceLocator.get<NavigationService>();
+  final AdministrationApplication application;
+
+  ApplicationPreviewCard({Key? key, required this.application})
+      : super(key: key);
+
+  @override
+  _ApplicationPreviewCardState createState() => _ApplicationPreviewCardState();
+}
+
+class _ApplicationPreviewCardState extends State<ApplicationPreviewCard> {
+  @override
+  Widget build(BuildContext context) {
+    // TODO: Move this stream into ViewModel. Need to give the VM the initial thread flag
+    // Unfortunately, this widget and it's behaviour are tightly coupled to the
+    // database service such that a view model cannot be between as the design
+    // is now (requires a given ThreadFlag to start)
+    return StreamBuilder<AdministrationApplication>(
+        stream: widget._adminService
+            .getUpdatedSpecificApplication(widget.application),
+        builder: (BuildContext context,
+            AsyncSnapshot<AdministrationApplication> snapshot) {
+          if (snapshot.hasData) {
+            return _buildPreviewCard(snapshot.data!);
+          } else if (snapshot.hasError) {
+            return outlinedBox(
+                child: Text(
+                  snapshot.error.toString(),
+                  style: GoogleFonts.raleway(
+                      color: Colors.red, fontSize: MediumTextSize),
+                ),
+                childAlignmentInBox: Alignment.center,
+                color: Colors.red);
+          } else {
+            return outlinedBox(
+                child: CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation(PersianGreen)),
+                childAlignmentInBox: Alignment.center,
+                color: PersianGreen);
+          }
+        });
+  }
+
+  Widget _buildPreviewCard(AdministrationApplication application) => Card(
+          child: Column(children: [
+        ListTile(
+          title: Text(
+            "Application to join leadership team",
+            style: GoogleFonts.raleway(
+                color: CharcoalOpaque,
+                fontSize: BodyTextSize,
+                letterSpacing: 1.1),
+          ),
+          subtitle: Text(
+            application.applicantName,
+            style: GoogleFonts.cabin(color: Charcoal, fontSize: MediumTextSize),
+            overflow: TextOverflow.ellipsis,
+          ),
+          trailing: Icon(
+            Icons.account_circle,
+            size: 50,
+          ),
+          onTap: () => widget._navigationService.navigateTo(
+              ApplicationReviewScreen.route,
+              arguments: application),
+        ),
+        Padding(
+            padding: EdgeInsets.all(5.0),
+            child: Row(
+              children: [
+                Spacer(),
+                outlinedBox(
+                    child: Text(ApprovalStatusString.toDisplayString(
+                        application.approvalStatus)),
+                    childAlignmentInBox: Alignment.center,
+                    color: application.approvalStatus == ApprovalStatus.approved
+                        ? PersianGreen
+                        : Charcoal)
+              ],
+            ))
+      ]));
+}

--- a/app/lib/ui/widget/application_preview_card.dart
+++ b/app/lib/ui/widget/application_preview_card.dart
@@ -82,8 +82,15 @@ class _ApplicationPreviewCardState extends State<ApplicationPreviewCard> {
               children: [
                 Spacer(),
                 outlinedBox(
-                    child: Text(ApprovalStatusString.toDisplayString(
-                        application.approvalStatus)),
+                    child: Text(
+                      ApprovalStatusString.toDisplayString(
+                          application.approvalStatus),
+                      style: TextStyle(
+                          color: application.approvalStatus ==
+                                  ApprovalStatus.approved
+                              ? PersianGreen
+                              : Charcoal),
+                    ),
                     childAlignmentInBox: Alignment.center,
                     color: application.approvalStatus == ApprovalStatus.approved
                         ? PersianGreen

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -175,7 +175,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:


### PR DESCRIPTION
Closes #68 .

This PR adds:
1. The preview card for applications
2. The preview screen of applications
3. The review page for applications
4. Associated cleanup of functions, interfaces

> With these changes, it's obvious that the home page should be split up. Maybe move the admin features into a totally separate page

***

Changes look like:

![Screen Shot 2021-04-05 at 4 19 16 PM](https://user-images.githubusercontent.com/32527219/113633809-da49e200-962a-11eb-8e8d-6aa7c4431bda.png)
![Screen Shot 2021-04-05 at 4 19 41 PM](https://user-images.githubusercontent.com/32527219/113633814-dddd6900-962a-11eb-8824-c41b00bf019d.png)
![Screen Shot 2021-04-05 at 4 20 11 PM](https://user-images.githubusercontent.com/32527219/113633815-dddd6900-962a-11eb-8555-e375d7803142.png)
![Screen Shot 2021-04-05 at 4 19 56 PM](https://user-images.githubusercontent.com/32527219/113633818-e03fc300-962a-11eb-8304-9976d62868c1.png)
