### PR TITLE
Add about and legal screen

### DIFF
--- a/app/lib/app_route_generator.dart
+++ b/app/lib/app_route_generator.dart
@@ -3,6 +3,7 @@ import 'package:app/core/thread.dart';
 import 'package:app/core/thread_type.dart';
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/about_and_legal_screen.dart';
 import 'package:app/ui/screen/application_confirmation_screen.dart';
 import 'package:app/ui/screen/application_review_screen.dart';
 import 'package:app/ui/screen/application_screen.dart';
@@ -51,6 +52,9 @@ class AppRouteGenerator {
             return thread.isAnnouncement
                 ? ThreadDisplayScreen<AnnouncementViewModel>(thread: thread)
                 : ThreadDisplayScreen<ThreadViewModel>(thread: thread);
+
+          case AboutAndLegalScreen.route:
+            return AboutAndLegalScreen();
 
           // Account-required screens, only available if logged in
           case NewThreadScreen.route:

--- a/app/lib/service/service_locator.dart
+++ b/app/lib/service/service_locator.dart
@@ -5,6 +5,7 @@ import 'package:app/service/firestore_admin_service.dart';
 import 'package:app/service/firestore_announcement_service.dart';
 import 'package:app/service/firestore_thread_service.dart';
 import 'package:app/service/navigation_service.dart';
+import 'package:app/ui/view_model/about_and_legal_view_model.dart';
 import 'package:app/ui/view_model/all_questions_view_model.dart';
 import 'package:app/ui/view_model/announcement_view_model.dart';
 import 'package:app/ui/view_model/announcements_view_model.dart';
@@ -57,5 +58,6 @@ class ServiceLocator {
     get.registerFactory<ApplicationViewModel>(() => ApplicationViewModel());
     get.registerFactory<ApplicationsToReviewViewModel>(
         () => ApplicationsToReviewViewModel());
+    get.registerFactory<AboutAndLegalViewModel>(() => AboutAndLegalViewModel());
   }
 }

--- a/app/lib/ui/community_meal_planner_forum_app.dart
+++ b/app/lib/ui/community_meal_planner_forum_app.dart
@@ -14,6 +14,7 @@ class CommunityMealPlannerForumApp extends StatelessWidget {
     return MaterialApp(
       title: 'Community of Meal Planners Forums',
       theme: ThemeData(
+          primaryColor: PersianGreen,
           visualDensity: VisualDensity.adaptivePlatformDensity,
           textTheme: TextTheme(
               bodyText2:

--- a/app/lib/ui/screen/about_and_legal_screen.dart
+++ b/app/lib/ui/screen/about_and_legal_screen.dart
@@ -1,0 +1,84 @@
+import 'package:app/ui/style.dart';
+import 'package:app/ui/view_model/about_and_legal_view_model.dart';
+import 'package:app/ui/widget/custom_app_bar.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class AboutAndLegalScreen extends StatefulWidget {
+  static const route = '/aboutAndLegal';
+
+  AboutAndLegalScreen({Key? key}) : super(key: key);
+
+  @override
+  _AboutAndLegalScreenState createState() => _AboutAndLegalScreenState();
+}
+
+class _AboutAndLegalScreenState extends State<AboutAndLegalScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return TemplateViewModel<AboutAndLegalViewModel>(
+      builder: (context, model, child) => Scaffold(
+        appBar: customAppBar(
+            leftButtonText: "Signup",
+            centreButtonText: "Home",
+            rightButtonText: "FAQ",
+            leftButtonAction: () {
+              // TODO
+            },
+            centreButtonAction: model.navigateToHomeScreen,
+            rightButtonAction: () {
+              // TODO
+            }),
+        body: SingleChildScrollView(
+            child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.all(10.0),
+              child: Text(
+                'About this application',
+                style: GoogleFonts.raleway(
+                    fontWeight: FontWeight.bold,
+                    color: Charcoal,
+                    fontSize: LargeTextSize),
+              ),
+            ),
+            outlinedBox(
+                child: Text(
+                  '''This application is intended to support Goal 12: Ensure sustainable consumption and production patterns of the UN's 17 Goal for Sustainable Development:
+            \nThis project aims to provide members of the meal planning community with a space (forum) for relevant discussion and critique of recipes, practices, and tools that can be received by meal planning companies/tool developers.
+            ''',
+                  style: GoogleFonts.raleway(fontSize: MediumTextSize),
+                ),
+                childAlignmentInBox: Alignment.center,
+                color: Charcoal),
+            ButtonBar(
+                buttonPadding: EdgeInsets.only(left: 20.0),
+                overflowButtonSpacing: 20.0,
+                children: [
+                  elevatedButton(
+                      onPressed: () => showLicensePage(
+                            context: context,
+                            applicationName:
+                                "Community of Meal Planners Forums",
+                            applicationVersion: 'Version 0.0.1',
+                            applicationLegalese:
+                                'This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License.\n',
+                          ),
+                      text: 'Legal',
+                      pressedColor: PersianGreen,
+                      color: PersianGreenOpaque),
+                  elevatedButton(
+                      text: "Project GitHub",
+                      onPressed: () async => launch(
+                          "https://github.com/holtzmak/Community-Meal-Planner-Forum"),
+                      color: PersianGreen,
+                      pressedColor: PersianGreenOpaque)
+                ]),
+          ],
+        )),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/view_model/about_and_legal_view_model.dart
+++ b/app/lib/ui/view_model/about_and_legal_view_model.dart
@@ -1,0 +1,15 @@
+import 'package:app/service/navigation_service.dart';
+import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/about_and_legal_screen.dart';
+import 'package:app/ui/screen/home_screen.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+
+class AboutAndLegalViewModel extends ViewModel {
+  final _navigationService = ServiceLocator.get<NavigationService>();
+
+  void navigateToHomeScreen() =>
+      _navigationService.navigateBackUntil(HomeScreen.route);
+
+  void navigateToAboutAndLegalScreen() =>
+      _navigationService.navigateTo(AboutAndLegalScreen.route);
+}

--- a/app/lib/ui/widget/custom_bottom_app_bar.dart
+++ b/app/lib/ui/widget/custom_bottom_app_bar.dart
@@ -1,4 +1,6 @@
 import 'package:app/ui/style.dart';
+import 'package:app/ui/view_model/about_and_legal_view_model.dart';
+import 'package:app/ui/widget/template_view_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -9,32 +11,34 @@ class CustomBottomAppBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 75.0,
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [
-            PersianGreen,
-            Charcoal,
-          ],
-        ),
-      ),
-      child: Align(
-        alignment: Alignment.center,
-        child: ListTile(
-          leading: Icon(
-            Icons.help,
-            color: Colors.white,
-            size: 45.0,
+    return TemplateViewModel<AboutAndLegalViewModel>(
+      builder: (context, model, child) => Container(
+        height: 75.0,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              PersianGreen,
+              Charcoal,
+            ],
           ),
-          title: textButton(
-              text: "About this application",
-              onPressed: () => throw UnimplementedError("TODO"),
-              color: Colors.white),
-          // Creative Commons Attribution-ShareAlike 4.0 International License
-          trailing: Image(image: AssetImage('assets/cc-by-sa-4.0.png')),
+        ),
+        child: Align(
+          alignment: Alignment.center,
+          child: ListTile(
+            leading: Icon(
+              Icons.help,
+              color: Colors.white,
+              size: 45.0,
+            ),
+            title: textButton(
+                text: "About this application",
+                onPressed: model.navigateToAboutAndLegalScreen,
+                color: Colors.white),
+            // Creative Commons Attribution-ShareAlike 4.0 International License
+            trailing: Image(image: AssetImage('assets/cc-by-sa-4.0.png')),
+          ),
         ),
       ),
     );

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -595,6 +595,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.3"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   uuid:
     dependency: "direct main"
     description:
@@ -646,4 +688,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=1.22.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   google_fonts: ^2.0.0
   provider: ^5.0.0
   recase: ^4.0.0-nullsafety.0
+  url_launcher: ^6.0.3
   uuid: ^3.0.1
 
 dev_dependencies:


### PR DESCRIPTION
Closes #75 .

This PR adds the about and legal screens:
1. The about is a very short version of the GitHub blurbs, so I've added a button that links to the GitHub too
2. The legal screen has the license and the licenses of all open source software used

***

![Screen Shot 2021-04-08 at 11 15 50 PM](https://user-images.githubusercontent.com/32527219/114131894-9ff97280-98c0-11eb-9dca-d463896ffad2.png)
![Screen Shot 2021-04-08 at 11 18 32 PM](https://user-images.githubusercontent.com/32527219/114131996-cae3c680-98c0-11eb-8490-62f6ae9c0971.png)
