### PR TITLE
Separate admin from home

### DIFF
--- a/app/lib/app_route_generator.dart
+++ b/app/lib/app_route_generator.dart
@@ -4,6 +4,7 @@ import 'package:app/core/thread_type.dart';
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/ui/screen/about_and_legal_screen.dart';
+import 'package:app/ui/screen/admin_screen.dart';
 import 'package:app/ui/screen/application_confirmation_screen.dart';
 import 'package:app/ui/screen/application_review_screen.dart';
 import 'package:app/ui/screen/application_screen.dart';
@@ -57,6 +58,14 @@ class AppRouteGenerator {
             return AboutAndLegalScreen();
 
           // Account-required screens, only available if logged in
+          case AdminScreen.route:
+            if (isLoggedIn() && isAdmin()) {
+              return AdminScreen();
+            } else {
+              throw Exception(
+                  'You must be logged in to view this screen: ${settings.name}');
+            }
+
           case NewThreadScreen.route:
             final thread = settings.arguments as Thread;
             if (isLoggedIn() && isAdmin() && thread.isAnnouncement) {

--- a/app/lib/service/firestore_admin_service.dart
+++ b/app/lib/service/firestore_admin_service.dart
@@ -31,7 +31,7 @@ class FirestoreAdminService {
           .map((QuerySnapshot snapshot) => snapshot.docs
               .map((QueryDocumentSnapshot doc) =>
                   AdministrationApplication.fromJson(
-                      id: doc.id, json: doc.data()!))
+                      id: doc.id, json: doc.data()))
               .toList());
 
   Stream<AdministrationApplication> getUpdatedSpecificApplication(
@@ -55,6 +55,6 @@ class FirestoreAdminService {
       .snapshots()
       .map((QuerySnapshot snapshot) => snapshot.docs
           .map((QueryDocumentSnapshot doc) =>
-              ThreadFlag.fromJson(id: doc.id, json: doc.data()!))
+              ThreadFlag.fromJson(id: doc.id, json: doc.data()))
           .toList());
 }

--- a/app/lib/service/firestore_announcement_service.dart
+++ b/app/lib/service/firestore_announcement_service.dart
@@ -18,6 +18,6 @@ class FirestoreAnnouncementService extends TemplateFirestoreThreadService {
       .get()
       .then((QuerySnapshot snapshot) => snapshot.docs
           .map((QueryDocumentSnapshot doc) => Thread.fromJson(
-              id: doc.id, isAnnouncement: true, json: doc.data()!))
+              id: doc.id, isAnnouncement: true, json: doc.data()))
           .first);
 }

--- a/app/lib/service/firestore_thread_service.dart
+++ b/app/lib/service/firestore_thread_service.dart
@@ -17,7 +17,7 @@ class FirestoreThreadService extends TemplateFirestoreThreadService {
       .snapshots()
       .map((QuerySnapshot snapshot) => snapshot.docs
           .map((QueryDocumentSnapshot doc) => Thread.fromJson(
-              id: doc.id, isAnnouncement: false, json: doc.data()!))
+              id: doc.id, isAnnouncement: false, json: doc.data()))
           .toList());
 
   Future<Thread> getLatestAccountSpecificThread(String id) => _firestore
@@ -28,6 +28,6 @@ class FirestoreThreadService extends TemplateFirestoreThreadService {
       .get()
       .then((QuerySnapshot snapshot) => snapshot.docs
           .map((QueryDocumentSnapshot doc) => Thread.fromJson(
-              id: doc.id, isAnnouncement: false, json: doc.data()!))
+              id: doc.id, isAnnouncement: false, json: doc.data()))
           .first);
 }

--- a/app/lib/service/service_locator.dart
+++ b/app/lib/service/service_locator.dart
@@ -6,6 +6,7 @@ import 'package:app/service/firestore_announcement_service.dart';
 import 'package:app/service/firestore_thread_service.dart';
 import 'package:app/service/navigation_service.dart';
 import 'package:app/ui/view_model/about_and_legal_view_model.dart';
+import 'package:app/ui/view_model/admin_view_model.dart';
 import 'package:app/ui/view_model/all_questions_view_model.dart';
 import 'package:app/ui/view_model/announcement_view_model.dart';
 import 'package:app/ui/view_model/announcements_view_model.dart';
@@ -45,6 +46,7 @@ class ServiceLocator {
     get.registerFactory<SignUpViewModel>(() => SignUpViewModel());
     get.registerFactory<LogInViewModel>(() => LogInViewModel());
     get.registerFactory<HomeViewModel>(() => HomeViewModel());
+    get.registerFactory<AdminViewModel>(() => AdminViewModel());
     get.registerFactory<ThreadViewModel>(() => ThreadViewModel());
     get.registerFactory<AnnouncementViewModel>(() => AnnouncementViewModel());
     get.registerFactory<MyQuestionsViewModel>(() => MyQuestionsViewModel());

--- a/app/lib/service/template_firestore_thread_service.dart
+++ b/app/lib/service/template_firestore_thread_service.dart
@@ -42,9 +42,7 @@ abstract class TemplateFirestoreThreadService {
       .snapshots()
       .map((QuerySnapshot snapshot) => snapshot.docs
           .map((QueryDocumentSnapshot doc) => Thread.fromJson(
-              id: doc.id,
-              isAnnouncement: isForAnnouncements,
-              json: doc.data()!))
+              id: doc.id, isAnnouncement: isForAnnouncements, json: doc.data()))
           .toList());
 
   Stream<Thread> getUpdatedSpecificThread(String id) => _firestore
@@ -64,6 +62,6 @@ abstract class TemplateFirestoreThreadService {
       .snapshots()
       .map((QuerySnapshot snapshot) => snapshot.docs
           .map((QueryDocumentSnapshot doc) =>
-              Post.fromJson(id: doc.id, json: doc.data()!))
+              Post.fromJson(id: doc.id, json: doc.data()))
           .toList());
 }

--- a/app/lib/ui/screen/admin_screen.dart
+++ b/app/lib/ui/screen/admin_screen.dart
@@ -1,0 +1,73 @@
+import 'package:app/ui/style.dart';
+import 'package:app/ui/view_model/admin_view_model.dart';
+import 'package:app/ui/widget/custom_app_bar.dart';
+import 'package:app/ui/widget/custom_bottom_app_bar.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AdminScreen extends StatefulWidget {
+  static const route = '/admin';
+
+  AdminScreen({Key? key}) : super(key: key);
+
+  @override
+  _AdminScreenState createState() => _AdminScreenState();
+}
+
+class _AdminScreenState extends State<AdminScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return TemplateViewModel<AdminViewModel>(
+      builder: (context, model, child) => Scaffold(
+        appBar: customAppBar(
+            leftButtonText: "Account",
+            centreButtonText: "Home",
+            rightButtonText: "FAQ",
+            leftButtonAction: () {
+              // TODO
+            },
+            centreButtonAction: model.navigateToHomeScreen,
+            rightButtonAction: () {
+              // TODO
+            }),
+        bottomNavigationBar: CustomBottomAppBar.get(),
+        body: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.only(bottom: 15.0),
+            ),
+            Text(
+              'Admin and Leadership-only tasks',
+              style: GoogleFonts.raleway(
+                  fontWeight: FontWeight.bold,
+                  color: Charcoal,
+                  fontSize: LargeTextSize),
+            ),
+            Padding(
+              padding: EdgeInsets.only(bottom: 15.0),
+            ),
+            stretchedButton(
+                text: "Calls for question reviews",
+                trailing: Icon(Icons.arrow_forward_ios_outlined),
+                onPressed: model.navigateToFlaggedThreadsScreen,
+                color: PersianGreen,
+                pressedColor: PersianGreenOpaque),
+            Padding(
+              padding: EdgeInsets.only(bottom: 15.0),
+            ),
+            stretchedButton(
+                text: "Review admin applications",
+                trailing: Icon(Icons.arrow_forward_ios_outlined),
+                onPressed: model.navigateToApplicationsToReviewScreen,
+                color: BurntSienna,
+                pressedColor: BurntSiennaOpaque),
+            Padding(
+              padding: EdgeInsets.only(bottom: 15.0),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/ui/screen/home_screen.dart
+++ b/app/lib/ui/screen/home_screen.dart
@@ -46,17 +46,23 @@ class _HomeScreenState extends State<HomeScreen> {
                         child: SingleChildScrollView(
                           child: Column(
                             children: [
-                              if (model.currentUserIsAdmin)
-                                _buildCallsForReviewButton(model),
-                              if (model.currentUserIsAdmin)
-                                _buildReviewApplicationsButton(model),
-                              stretchedButton(
-                                  text: "All Questions",
-                                  trailing:
-                                      Icon(Icons.arrow_forward_ios_outlined),
+                              ElevatedButton(
                                   onPressed: model.navigateToAllQuestionsScreen,
-                                  color: PersianGreen,
-                                  pressedColor: PersianGreenOpaque),
+                                  style: ElevatedButton.styleFrom(
+                                    minimumSize: Size(100.0, 80.0),
+                                    primary: PersianGreen,
+                                  ),
+                                  child: Row(
+                                    children: [
+                                      Text(
+                                        "All Questions",
+                                        style: GoogleFonts.cabin(
+                                            fontSize: LargeTextSize),
+                                      ),
+                                      Spacer(),
+                                      Icon(Icons.arrow_forward_ios_outlined),
+                                    ],
+                                  )),
                               Padding(
                                 padding: EdgeInsets.only(bottom: 15.0),
                               ),
@@ -175,22 +181,6 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Widget _buildCallsForReviewButton(HomeViewModel model) {
-    return Column(
-      children: [
-        stretchedButton(
-            text: "Calls for question reviews",
-            trailing: Icon(Icons.arrow_forward_ios_outlined),
-            onPressed: model.navigateToFlaggedThreadsScreen,
-            color: PersianGreen,
-            pressedColor: PersianGreenOpaque),
-        Padding(
-          padding: EdgeInsets.only(bottom: 15.0),
-        ),
-      ],
-    );
-  }
-
   Widget _buildApplicationButton(HomeViewModel model) {
     return Column(
       children: [
@@ -203,22 +193,6 @@ class _HomeScreenState extends State<HomeScreen> {
             onPressed: model.navigateToApplicationConfirmationScreen,
             color: Charcoal,
             pressedColor: CharcoalOpaque),
-      ],
-    );
-  }
-
-  Widget _buildReviewApplicationsButton(HomeViewModel model) {
-    return Column(
-      children: [
-        stretchedButton(
-            text: "Review admin applications",
-            trailing: Icon(Icons.arrow_forward_ios_outlined),
-            onPressed: model.navigateToApplicationsToReviewScreen,
-            color: BurntSienna,
-            pressedColor: BurntSiennaOpaque),
-        Padding(
-          padding: EdgeInsets.only(bottom: 15.0),
-        ),
       ],
     );
   }

--- a/app/lib/ui/view_model/admin_view_model.dart
+++ b/app/lib/ui/view_model/admin_view_model.dart
@@ -1,0 +1,23 @@
+import 'package:app/service/navigation_service.dart';
+import 'package:app/service/service_locator.dart';
+import 'package:app/ui/screen/admin_screen.dart';
+import 'package:app/ui/screen/applications_to_review_screen.dart';
+import 'package:app/ui/screen/flagged_threads_screen.dart';
+import 'package:app/ui/screen/home_screen.dart';
+import 'package:app/ui/widget/template_view_model.dart';
+
+class AdminViewModel extends ViewModel {
+  final _navigationService = ServiceLocator.get<NavigationService>();
+
+  void navigateToHomeScreen() =>
+      _navigationService.navigateBackUntil(HomeScreen.route);
+
+  void navigateToFlaggedThreadsScreen() =>
+      _navigationService.navigateTo(FlaggedThreadsScreen.route);
+
+  void navigateToApplicationsToReviewScreen() =>
+      _navigationService.navigateTo(ApplicationsToReviewScreen.route);
+
+  void navigateToAdminScreen() =>
+      _navigationService.navigateTo(AdminScreen.route);
+}

--- a/app/lib/ui/view_model/home_view_model.dart
+++ b/app/lib/ui/view_model/home_view_model.dart
@@ -12,8 +12,6 @@ import 'package:app/service/navigation_service.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/service/template_firestore_thread_service.dart';
 import 'package:app/ui/screen/application_confirmation_screen.dart';
-import 'package:app/ui/screen/applications_to_review_screen.dart';
-import 'package:app/ui/screen/flagged_threads_screen.dart';
 import 'package:app/ui/screen/new_thread_screen.dart';
 import 'package:app/ui/screen/sign_up_screen.dart';
 import 'package:app/ui/screen/specific_threads_screen.dart';
@@ -171,17 +169,11 @@ class HomeViewModel extends ViewModel {
       _navigationService.navigateTo(SpecificThreadsScreen.route,
           arguments: ThreadType.allQuestions);
 
-  void navigateToFlaggedThreadsScreen() =>
-      _navigationService.navigateTo(FlaggedThreadsScreen.route);
-
   void navigateToThreadDisplayScreen(Thread thread) => _navigationService
       .navigateTo(ThreadDisplayScreen.route, arguments: thread);
 
   void navigateToApplicationConfirmationScreen() =>
       _navigationService.navigateTo(ApplicationConfirmationScreen.route);
-
-  void navigateToApplicationsToReviewScreen() =>
-      _navigationService.navigateTo(ApplicationsToReviewScreen.route);
 
   void logOut() => _firebaseAuthService.signOut();
 }

--- a/app/lib/ui/widget/custom_app_bar.dart
+++ b/app/lib/ui/widget/custom_app_bar.dart
@@ -1,6 +1,8 @@
 import 'package:app/service/firebase_auth_service.dart';
 import 'package:app/service/service_locator.dart';
 import 'package:app/ui/style.dart';
+import 'package:app/ui/view_model/admin_view_model.dart';
+import 'package:app/ui/widget/template_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -12,7 +14,7 @@ PreferredSize customAppBar(
         required VoidCallback centreButtonAction,
         required VoidCallback rightButtonAction}) =>
     PreferredSize(
-        preferredSize: Size.fromHeight(175.0),
+        preferredSize: Size.fromHeight(200.0),
         child: _CustomAppBarInner(
           leftButtonText: leftButtonText,
           centreButtonText: centreButtonText,
@@ -67,97 +69,101 @@ class _CustomAppBarInnerState extends State<_CustomAppBarInner> {
   }
 
   Widget _buildCustomAppBar(bool isAdmin) {
-    return Container(
-        color: isAdmin ? IndependencePurple : BurntSienna,
-        child: Padding(
-            padding: EdgeInsets.only(top: 50.0),
-            child: Column(mainAxisSize: MainAxisSize.min, children: [
-              Container(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: isAdmin
-                        ? [
-                            IndependencePurple,
-                            TerraCottaPink,
-                          ]
-                        : [
-                            BurntSienna,
-                            SandyBrown,
-                          ],
-                  ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: [
-                    Padding(padding: EdgeInsets.only(left: 40.0)),
-                    Icon(
-                      Icons.account_circle_outlined,
-                      color: Colors.white,
-                      size: 75.0,
+    return TemplateViewModel<AdminViewModel>(
+        builder: (context, model, child) => Container(
+            color: isAdmin ? IndependencePurple : BurntSienna,
+            child: Padding(
+                padding: EdgeInsets.only(top: 50.0),
+                child: Column(mainAxisSize: MainAxisSize.min, children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: isAdmin
+                            ? [
+                                IndependencePurple,
+                                TerraCottaPink,
+                              ]
+                            : [
+                                BurntSienna,
+                                SandyBrown,
+                              ],
+                      ),
                     ),
-                    Flexible(
-                        child: Text(
-                      'Community of Meal Planners Forums',
-                      style: GoogleFonts.cabin(
-                          fontWeight: FontWeight.bold,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        Padding(padding: EdgeInsets.only(left: 40.0)),
+                        Icon(
+                          Icons.account_circle_outlined,
                           color: Colors.white,
-                          fontSize: LargeTextSize),
-                    )),
-                  ],
-                ),
-              ),
-              Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
-                Expanded(
-                    child: Container(
-                  decoration: BoxDecoration(
-                      color: isAdmin ? TerraCottaPink : PersianGreenOpaque,
-                      border: Border.all(color: Colors.white)),
-                  child: textButton(
-                      text: widget.leftButtonText,
-                      onPressed: widget.leftButtonAction,
-                      color: Colors.white),
-                )),
-                Expanded(
-                    child: Container(
-                  decoration: BoxDecoration(
-                      color: isAdmin ? TerraCottaPink : PersianGreenOpaque,
-                      border: Border.all(color: Colors.white)),
-                  child: textButton(
-                      text: widget.centreButtonText,
-                      onPressed: widget.centreButtonAction,
-                      color: Colors.white),
-                )),
-                Expanded(
-                    child: Container(
-                  decoration: BoxDecoration(
-                      color: isAdmin ? TerraCottaPink : PersianGreenOpaque,
-                      border: Border.all(color: Colors.white)),
-                  child: textButton(
-                      text: widget.rightButtonText,
-                      onPressed: widget.rightButtonAction,
-                      color: Colors.white),
-                ))
-              ]),
-              if (isAdmin == true)
-                Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      Expanded(
-                          child: Container(
-                        padding: EdgeInsets.all(5.0),
-                        decoration: BoxDecoration(
-                            color: IndependencePurple,
-                            border: Border.all(color: Colors.white)),
-                        child: Text(
-                          "ADMINISTRATION",
-                          textAlign: TextAlign.center,
-                          style: GoogleFonts.cabin(
-                              color: Colors.white, fontSize: LargeTextSize),
+                          size: 75.0,
                         ),
-                      ))
-                    ])
-            ])));
+                        Flexible(
+                            child: Text(
+                          'Community of Meal Planners Forums',
+                          style: GoogleFonts.cabin(
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                              fontSize: LargeTextSize),
+                        )),
+                      ],
+                    ),
+                  ),
+                  Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        Expanded(
+                            child: Container(
+                          decoration: BoxDecoration(
+                              color:
+                                  isAdmin ? TerraCottaPink : PersianGreenOpaque,
+                              border: Border.all(color: Colors.white)),
+                          child: textButton(
+                              text: widget.leftButtonText,
+                              onPressed: widget.leftButtonAction,
+                              color: Colors.white),
+                        )),
+                        Expanded(
+                            child: Container(
+                          decoration: BoxDecoration(
+                              color:
+                                  isAdmin ? TerraCottaPink : PersianGreenOpaque,
+                              border: Border.all(color: Colors.white)),
+                          child: textButton(
+                              text: widget.centreButtonText,
+                              onPressed: widget.centreButtonAction,
+                              color: Colors.white),
+                        )),
+                        Expanded(
+                            child: Container(
+                          decoration: BoxDecoration(
+                              color:
+                                  isAdmin ? TerraCottaPink : PersianGreenOpaque,
+                              border: Border.all(color: Colors.white)),
+                          child: textButton(
+                              text: widget.rightButtonText,
+                              onPressed: widget.rightButtonAction,
+                              color: Colors.white),
+                        ))
+                      ]),
+                  if (isAdmin == true)
+                    Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                        children: [
+                          Expanded(
+                              child: Container(
+                            padding: EdgeInsets.all(5.0),
+                            decoration: BoxDecoration(
+                                color: IndependencePurple,
+                                border: Border.all(color: Colors.white)),
+                            child: textButton(
+                                text: "ADMINISTRATION",
+                                onPressed: model.navigateToAdminScreen,
+                                color: Colors.white),
+                          ))
+                        ])
+                ]))));
   }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "19.0.0"
+    version: "20.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   args:
     dependency: transitive
     description:
@@ -133,21 +133,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   code_builder:
     dependency: transitive
     description:
@@ -217,28 +217,28 @@ packages:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.3"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.2"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -643,7 +643,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.4"
   vector_math:
     dependency: transitive
     description:

--- a/app/test/service/firebase_auth_service_test.mocks.dart
+++ b/app/test/service/firebase_auth_service_test.mocks.dart
@@ -465,4 +465,7 @@ class MockAccount extends _i1.Mock implements _i7.Account {
       (super.noSuchMethod(
           Invocation.method(#withAboutMeDescription, [newDescription]),
           returnValue: _FakeAccount()) as _i7.Account);
+  @override
+  _i7.Account asAdmin() => (super.noSuchMethod(Invocation.method(#asAdmin, []),
+      returnValue: _FakeAccount()) as _i7.Account);
 }

--- a/app/test/service/firestore_thread_service_test.mocks.dart
+++ b/app/test/service/firestore_thread_service_test.mocks.dart
@@ -493,4 +493,8 @@ class MockQueryDocumentSnapshot extends _i1.Mock
   _i4.SnapshotMetadata get metadata =>
       (super.noSuchMethod(Invocation.getter(#metadata),
           returnValue: _FakeSnapshotMetadata()) as _i4.SnapshotMetadata);
+  @override
+  Map<String, dynamic> data() =>
+      (super.noSuchMethod(Invocation.method(#data, []),
+          returnValue: <String, dynamic>{}) as Map<String, dynamic>);
 }


### PR DESCRIPTION
Closes #87 .

This PR separates admin/leadership options from the home page. Made the "All Questions" button bigger to emphasize its importance.

***

Changes look like:

![Screen Shot 2021-04-08 at 11 49 11 PM](https://user-images.githubusercontent.com/32527219/114134503-18fac900-98c5-11eb-8941-10567ce98255.png)
![Screen Shot 2021-04-08 at 11 49 25 PM](https://user-images.githubusercontent.com/32527219/114134507-19935f80-98c5-11eb-9645-685c2a20990e.png)
