### PR TITLE
Add search bar to questions and announcements

### DIFF
--- a/app/lib/ui/screen/specific_threads_screen.dart
+++ b/app/lib/ui/screen/specific_threads_screen.dart
@@ -45,25 +45,37 @@ class _SpecificThreadsScreenState<T extends SpecificItemViewModel>
               // TODO
             }),
         bottomNavigationBar: CustomBottomAppBar.get(),
-        body: model.items.isEmpty
-            ? Center(
-                child: Container(
-                margin: EdgeInsets.all(50.0),
-                child: Card(
-                  child: ListTile(
-                    title: Text(
-                      "There is no information to show yet",
-                      textAlign: TextAlign.center,
-                      style: TextStyle(fontSize: LargeTextSize),
+        body: Column(children: [
+          Card(
+              child: Padding(
+                  padding: EdgeInsets.all(5.0),
+                  child: TextFormField(
+                    decoration: InputDecoration(
+                        border: OutlineInputBorder(), labelText: "Search"),
+                    onFieldSubmitted: (String searchTerm) =>
+                        model.filterBySearchTerm(searchTerm),
+                  ))),
+          model.items.isEmpty
+              ? Center(
+                  child: Container(
+                  margin: EdgeInsets.all(50.0),
+                  child: Card(
+                    child: ListTile(
+                      title: Text(
+                        "There is no information to show yet",
+                        textAlign: TextAlign.center,
+                        style: TextStyle(fontSize: LargeTextSize),
+                      ),
                     ),
                   ),
-                ),
-              ))
-            : ListView.builder(
-                itemCount: model.items.length,
-                itemBuilder: (context, index) =>
-                    createPreview(model, model.items[index]),
-              ),
+                ))
+              : Expanded(
+                  child: ListView.builder(
+                  itemCount: model.filteredItems.length,
+                  itemBuilder: (context, index) =>
+                      createPreview(model, model.filteredItems[index]),
+                )),
+        ]),
       ),
     );
   }

--- a/app/lib/ui/view_model/specific_item_view_model.dart
+++ b/app/lib/ui/view_model/specific_item_view_model.dart
@@ -8,16 +8,29 @@ import 'package:app/ui/widget/template_view_model.dart';
 abstract class SpecificItemViewModel<T> extends ViewModel {
   final _navigationService = ServiceLocator.get<NavigationService>();
   final List<T> _items = [];
+  List<T> _filteredItems = [];
 
   List<T> get items => List.unmodifiable(_items);
 
-  void addAll(List<T> threads) {
-    _items.addAll(threads);
+  List<T> get filteredItems => List.unmodifiable(_filteredItems);
+
+  void addAll(List<T> items) {
+    _items.addAll(items);
+    _filteredItems.addAll(items);
     notifyListeners();
   }
 
   void removeAll() {
     _items.clear();
+    _filteredItems.clear();
+    notifyListeners();
+  }
+
+  void filterBySearchTerm(String searchTerm) {
+    _filteredItems = _items
+        .where((T it) =>
+            it.toString().toLowerCase().contains(searchTerm.toLowerCase()))
+        .toList();
     notifyListeners();
   }
 


### PR DESCRIPTION
Closes #61 

This PR adds. simple search bar to questions/announcements. A way this could potentially evolve in the future is to drop pre-determined topics/sub-topics and allow people to have whatever they want, since searching is so easy.

***

Changes simply look like:

![Screen Shot 2021-04-09 at 12 04 31 AM](https://user-images.githubusercontent.com/32527219/114136350-c8d13600-98c7-11eb-90ef-1ee5421c22d9.png)
![Screen Shot 2021-04-09 at 12 04 46 AM](https://user-images.githubusercontent.com/32527219/114136354-c969cc80-98c7-11eb-8ced-a253bfe9a10f.png)
